### PR TITLE
fix: 自作MDパーサーを marked.js に置換（コードブロック・リスト対応）

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,7 +395,8 @@
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
-        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/",
+        "marked": "https://cdn.jsdelivr.net/npm/marked@15.0.7/lib/marked.esm.js"
       }
     }
   </script>


### PR DESCRIPTION
## 問題

viewer.js の自作 Markdown パーサーにコードブロック（` ``` `）やリストの処理がなく、draft.md 内のフロー図やコードマークアップが無視されていた。

```
外的Container（養育者との相互作用）
↓
反復的経験
```

上記のような構造が `<p>` 1つに結合され、改行もバッククォートも消えていた。

## 原因

`markdownToHtml()` が対応していたのは h1-h4、テーブル、blockquote、hr、段落、インライン装飾のみ。コードブロック、リスト、ネストされた要素は一切未対応だった。

## 変更内容

- **marked.js** (v15.0.7, ESM) を CDN 経由で導入
- `index.html`: importmap に `marked` を追加
- `src/viewer.js`:
  - 自作パーサー (`markdownToHtml`, `inlineMarkdown`) を削除
  - `marked.parse()` に置換
  - `breaks: true` で単一改行を `<br>` に変換（フロー図の矢印構造を保持）
  - `gfm: true` でテーブル等のGFM記法を維持
  - コードブロック・リスト用の CSS を追加
  - `parseFrontmatter`, DOM 操作, ビューアーUI は変更なし

## CSSの追加

- `pre` / `code`: ダークテーマに合わせたコードブロックスタイル
- `ul` / `ol` / `li`: リスト表示
- `thead`: テーブルヘッダー境界線
- `img`: 画像の最大幅制限

## 設計判断

自作パーサーを拡張するのではなく、実績あるライブラリに委ねることで：
- 今後新たなMarkdown記法への対応が自動的に得られる
- draft.md を PDF 出力専用の書き方に制約する必要がなくなる（汎用性の確保）
- メンテナンスコストがほぼゼロになる