### PR TITLE
fix(nav): auto-collapse mobile topbar on tap

### DIFF
--- a/src/consciousness.js
+++ b/src/consciousness.js
@@ -11,6 +11,7 @@ import { attachResizeHandler, createNavMeshFinder, startRenderLoop } from './mai
 import { getOrbScreenData, refreshNavLanguage, updateNavLabels, updateXLogo, updateXLogoLabel } from './nav-objects.js';
 import { refreshDevlogLanguage } from './devlog/devlog.js';
 import { initLangToggle } from './lang-toggle.js';
+import { initMobileNavAutoCollapse } from './main/mobile-nav.js';
 import { initTopbarConsole } from './topbar-console.js';
 import { detectLang, LANG_CHANGE_EVENT } from './i18n.js';
 import { breathConfig, liquidParams, sceneParams, toggles } from './config.js';
@@ -109,6 +110,7 @@ const initialLang = detectLang();
 applyPageLanguage(initialLang);
 applyConsciousnessCopy(initialLang);
 initLangToggle();
+initMobileNavAutoCollapse();
 initTopbarConsole();
 
 const container = document.getElementById('canvas-container');

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import { attachResizeHandler, createNavMeshFinder, startRenderLoop } from './mai
 import { getOrbScreenData, refreshNavLanguage, updateNavLabels, updateXLogo, updateXLogoLabel } from './nav-objects.js';
 import { refreshDevlogLanguage } from './devlog/devlog.js';
 import { initLangToggle } from './lang-toggle.js';
+import { initMobileNavAutoCollapse } from './main/mobile-nav.js';
 import { initTopbarConsole } from './topbar-console.js';
 import { detectLang } from './i18n.js';
 import { breathConfig, liquidParams, toggles } from './config.js';
@@ -28,6 +29,7 @@ initMouseTracking();
 
 applyPageLanguage(detectLang());
 initLangToggle();
+initMobileNavAutoCollapse();
 initTopbarConsole();
 
 const container = document.getElementById('canvas-container');

--- a/src/main/mobile-nav.js
+++ b/src/main/mobile-nav.js
@@ -1,0 +1,14 @@
+export function initMobileNavAutoCollapse() {
+    const nav = document.getElementById('kessonTopbarNav');
+    if (!nav) return;
+
+    nav.querySelectorAll('.nav-link, [data-bs-toggle="offcanvas"]').forEach((el) => {
+        el.addEventListener('click', () => {
+            if (window.innerWidth >= 768) return;
+            const collapseApi = window.bootstrap?.Collapse;
+            if (!collapseApi) return;
+            const collapse = collapseApi.getOrCreateInstance(nav, { toggle: false });
+            collapse.hide();
+        });
+    });
+}


### PR DESCRIPTION
## Summary
- add initMobileNavAutoCollapse shared module for topbar collapse behavior
- initialize it in both main.js and consciousness.js right after lang-toggle init
- on mobile (<768px), tapping nav links collapses #kessonTopbarNav via Bootstrap Collapse API

## Changed Files
- src/main/mobile-nav.js
- src/main.js
- src/consciousness.js

## Tests
- node --check src/main.js
- node --check src/consciousness.js
- node --check src/main/mobile-nav.js
- npm run test:devlog-nav (29 + 19 passed)

## Notes
- Issue番号が特定できなかったため、Closes #XX は未記載です。
