### PR TITLE
feat(guides): GUIDES セクション + MD モーダル表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,36 @@
   <!-- Articles出現タイミング調整スペーサー -->
   <div id="articles-spacer"></div>
 
+  <!-- Guides Section -->
+  <section id="guides-section">
+    <div class="section-content-wrap">
+      <div class="container">
+        <h2 class="section-heading">GUIDES</h2>
+        <div id="guides-feature-cards" class="row row-cols-1 row-cols-md-3 g-3"></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Guides MD Modal -->
+  <div class="modal fade" id="guides-md-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+      <div class="modal-content bg-dark text-light">
+        <div class="modal-header border-secondary">
+          <h5 class="modal-title" id="guides-md-modal-title"></h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <p class="text-body-secondary small mb-3" id="guides-md-meta"></p>
+          <div id="guides-md-content"></div>
+        </div>
+        <div class="modal-footer border-secondary">
+          <a id="guides-md-open-pdf" href="#" target="_blank" rel="noopener" class="btn btn-outline-light btn-sm">PDF</a>
+          <button type="button" id="guides-md-close-btn" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Articles Section -->
   <section id="articles-section">
     <div class="section-content-wrap">

--- a/src/guides.js
+++ b/src/guides.js
@@ -1,0 +1,381 @@
+import DOMPurify from 'dompurify';
+import { detectLang } from './i18n.js';
+
+function normalizeLang(lang) {
+    return lang === 'en' ? 'en' : 'ja';
+}
+
+const PJDHIRO_PAGES_BASE = 'https://uminomae.github.io/pjdhiro';
+const PJDHIRO_RAW_BASE = 'https://raw.githubusercontent.com/uminomae/pjdhiro/main';
+const KESSON_PATH = '/assets/kesson';
+const PJDHIRO_KESSON_PAGES = `${PJDHIRO_PAGES_BASE}${KESSON_PATH}`;
+const PJDHIRO_KESSON_RAW = `${PJDHIRO_RAW_BASE}${KESSON_PATH}`;
+
+const GUIDE_LINKS = [
+    {
+        key: 'general',
+        links: {
+            ja: {
+                mdUrl: `${PJDHIRO_KESSON_RAW}/guides/ja/md/kesson-general.md`,
+                pdfUrl: `${PJDHIRO_KESSON_PAGES}/guides/ja/pdf/kesson-general.pdf`,
+            },
+            en: {
+                mdUrl: `${PJDHIRO_KESSON_RAW}/guides/en/md/kesson-general.md`,
+                pdfUrl: `${PJDHIRO_KESSON_PAGES}/guides/en/pdf/kesson-general.pdf`,
+            },
+        },
+    },
+    {
+        key: 'designer',
+        links: {
+            ja: {
+                mdUrl: `${PJDHIRO_KESSON_RAW}/guides/ja/md/kesson-designer.md`,
+                pdfUrl: `${PJDHIRO_KESSON_PAGES}/guides/ja/pdf/kesson-designer.pdf`,
+            },
+            en: {
+                mdUrl: `${PJDHIRO_KESSON_RAW}/guides/en/md/kesson-designer.md`,
+                pdfUrl: `${PJDHIRO_KESSON_PAGES}/guides/en/pdf/kesson-designer.pdf`,
+            },
+        },
+    },
+    {
+        key: 'academic',
+        links: {
+            ja: {
+                mdUrl: `${PJDHIRO_KESSON_RAW}/guides/ja/md/kesson-academic.md`,
+                pdfUrl: `${PJDHIRO_KESSON_PAGES}/guides/ja/pdf/kesson-academic.pdf`,
+            },
+            en: {
+                mdUrl: `${PJDHIRO_KESSON_RAW}/guides/en/md/kesson-academic.md`,
+                pdfUrl: `${PJDHIRO_KESSON_PAGES}/guides/en/pdf/kesson-academic.pdf`,
+            },
+        },
+    },
+];
+
+const STRINGS = {
+    ja: {
+        modalLoading: 'Markdown を読み込み中...',
+        modalError: 'Markdown の読み込みに失敗しました。',
+        modalOpenPdf: 'PDFを開く',
+        modalPdfPending: 'PDF準備中',
+        modalClose: '閉じる',
+        modalModel: 'モデル',
+        modalGenerated: '生成日',
+        features: {
+            general: {
+                title: '一般向け',
+                modalTitle: '欠損駆動思考 — 概要版',
+                description: '欠損駆動思考の全体像を短く把握するための解説。',
+            },
+            designer: {
+                title: '設計者向け',
+                modalTitle: 'ラベルの下を見る',
+                description: '設計判断と運用視点で読む解説。',
+            },
+            academic: {
+                title: '専門家向け',
+                modalTitle: '欠損駆動思考 — 学術版',
+                description: '理論比較と検証観点を含む解説。',
+            },
+        },
+        featureRead: '解説を表示',
+        featurePdf: 'PDF',
+    },
+    en: {
+        modalLoading: 'Loading markdown...',
+        modalError: 'Failed to load markdown.',
+        modalOpenPdf: 'Open PDF',
+        modalPdfPending: 'PDF Pending',
+        modalClose: 'Close',
+        modalModel: 'Model',
+        modalGenerated: 'Generated',
+        features: {
+            general: {
+                title: 'General',
+                modalTitle: 'Kesson-Driven Thinking — Overview',
+                description: 'A concise overview of the kesson-driven thinking framework.',
+            },
+            designer: {
+                title: 'Designer',
+                modalTitle: 'Seeing Beneath the Label',
+                description: 'Guide focused on design and implementation decisions.',
+            },
+            academic: {
+                title: 'Expert',
+                modalTitle: 'Kesson-Driven Thinking — Academic',
+                description: 'Theory comparison and verification-oriented guide.',
+            },
+        },
+        featureRead: 'Open Guide',
+        featurePdf: 'PDF',
+    },
+};
+
+let markedParser = null;
+
+const state = {
+    lang: 'ja',
+    mdModalInstance: null,
+    mdRequestId: 0,
+    dom: {
+        featureCards: null,
+        mdModal: null,
+        mdModalTitle: null,
+        mdModalMeta: null,
+        mdModalContent: null,
+        mdOpenPdf: null,
+        mdCloseBtn: null,
+    },
+};
+
+function getStrings(lang = 'ja') {
+    return STRINGS[normalizeLang(lang)] || STRINGS.ja;
+}
+
+async function getMarked() {
+    if (!markedParser) {
+        const { marked } = await import('marked');
+        marked.setOptions({ breaks: true, gfm: true });
+        markedParser = marked;
+    }
+    return markedParser;
+}
+
+function parseFrontmatter(text) {
+    const match = text.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+    if (!match) return { meta: {}, body: text.trim() };
+
+    const meta = {};
+    match[1].split('\n').forEach((line) => {
+        const idx = line.indexOf(':');
+        if (idx <= 0) return;
+        const key = line.slice(0, idx).trim();
+        const val = line.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+        meta[key] = val;
+    });
+
+    return { meta, body: match[2].trim() };
+}
+
+function formatDate(isoStr) {
+    if (!isoStr) return '';
+    const match = String(isoStr).match(/^(\d{4}-\d{2}-\d{2})/);
+    return match ? match[1] : String(isoStr);
+}
+
+function normalizePdfBrowserUrl(rawUrl) {
+    if (typeof rawUrl !== 'string' || !rawUrl.trim()) return '';
+    try {
+        const parsed = new URL(rawUrl);
+        if (parsed.hostname === 'raw.githubusercontent.com' && /\.pdf(?:$|[?#])/i.test(parsed.pathname)) {
+            const parts = parsed.pathname.split('/').filter(Boolean);
+            if (parts.length >= 4) {
+                const [owner, repo, _branch, ...restPath] = parts;
+                return `https://${owner}.github.io/${repo}/${restPath.join('/')}`;
+            }
+        }
+        return rawUrl;
+    } catch {
+        return '';
+    }
+}
+
+function cacheDom() {
+    state.dom.featureCards = document.getElementById('guides-feature-cards');
+    state.dom.mdModal = document.getElementById('guides-md-modal');
+    state.dom.mdModalTitle = document.getElementById('guides-md-modal-title');
+    state.dom.mdModalMeta = document.getElementById('guides-md-meta');
+    state.dom.mdModalContent = document.getElementById('guides-md-content');
+    state.dom.mdOpenPdf = document.getElementById('guides-md-open-pdf');
+    state.dom.mdCloseBtn = document.getElementById('guides-md-close-btn');
+}
+
+function ensureMdModalInstance() {
+    if (!state.dom.mdModal || !globalThis.bootstrap?.Modal) return null;
+    if (!state.mdModalInstance) {
+        state.mdModalInstance = globalThis.bootstrap.Modal.getOrCreateInstance(state.dom.mdModal);
+    }
+    return state.mdModalInstance;
+}
+
+function setModalPdfButton(pdfUrl) {
+    if (!state.dom.mdOpenPdf) return;
+    const strings = getStrings(state.lang);
+    const browserPdfUrl = normalizePdfBrowserUrl(pdfUrl);
+    if (browserPdfUrl) {
+        state.dom.mdOpenPdf.href = browserPdfUrl;
+        state.dom.mdOpenPdf.textContent = strings.modalOpenPdf;
+        state.dom.mdOpenPdf.classList.remove('disabled');
+        state.dom.mdOpenPdf.setAttribute('aria-disabled', 'false');
+    } else {
+        state.dom.mdOpenPdf.href = '#';
+        state.dom.mdOpenPdf.textContent = strings.modalPdfPending;
+        state.dom.mdOpenPdf.classList.add('disabled');
+        state.dom.mdOpenPdf.setAttribute('aria-disabled', 'true');
+    }
+}
+
+function setMarkdownModalLoading({ title, pdfUrl }) {
+    const strings = getStrings(state.lang);
+
+    if (state.dom.mdModalTitle) {
+        state.dom.mdModalTitle.textContent = title || '';
+    }
+    if (state.dom.mdModalMeta) {
+        state.dom.mdModalMeta.textContent = '';
+    }
+    if (state.dom.mdModalContent) {
+        state.dom.mdModalContent.innerHTML = `
+            <div class="d-flex align-items-center gap-2 text-body-secondary">
+                <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+                <span>${strings.modalLoading}</span>
+            </div>
+        `;
+    }
+    setModalPdfButton(pdfUrl);
+
+    if (state.dom.mdCloseBtn) {
+        state.dom.mdCloseBtn.textContent = strings.modalClose;
+    }
+}
+
+async function openMarkdownModal({ mdUrl, title = '', pdfUrl = '' }) {
+    if (!mdUrl) return;
+
+    const modal = ensureMdModalInstance();
+    if (!modal) {
+        window.open(mdUrl, '_blank', 'noopener');
+        return;
+    }
+
+    const requestId = ++state.mdRequestId;
+    setMarkdownModalLoading({ title, pdfUrl });
+    modal.show();
+
+    try {
+        const marked = await getMarked();
+        const response = await fetch(mdUrl, { cache: 'no-store' });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const raw = await response.text();
+
+        if (requestId !== state.mdRequestId) return;
+
+        const { meta, body } = parseFrontmatter(raw);
+        const html = DOMPurify.sanitize(marked.parse(body || raw));
+
+        setModalPdfButton(pdfUrl);
+        if (state.dom.mdModalContent) {
+            state.dom.mdModalContent.innerHTML = `
+                <div class="md-article">
+                    <div class="md-body">${html}</div>
+                </div>
+            `;
+        }
+
+        const strings = getStrings(state.lang);
+        const metaParts = [];
+        if (meta.generator_model) metaParts.push(`${strings.modalModel}: ${meta.generator_model}`);
+        if (meta.generated) metaParts.push(`${strings.modalGenerated}: ${formatDate(meta.generated)}`);
+        if (state.dom.mdModalMeta) {
+            state.dom.mdModalMeta.textContent = metaParts.join(' / ');
+        }
+    } catch (error) {
+        console.warn('[guides] markdown load failed:', error);
+        if (requestId !== state.mdRequestId) return;
+        const strings = getStrings(state.lang);
+        if (state.dom.mdModalMeta) {
+            state.dom.mdModalMeta.textContent = '';
+        }
+        if (state.dom.mdModalContent) {
+            state.dom.mdModalContent.innerHTML = `<p class="text-warning-emphasis mb-0">${strings.modalError}</p>`;
+        }
+        setModalPdfButton(pdfUrl);
+    }
+}
+
+function renderFeatureCards() {
+    if (!state.dom.featureCards) return;
+
+    const strings = getStrings(state.lang);
+    state.dom.featureCards.innerHTML = '';
+
+    const fragment = document.createDocumentFragment();
+    GUIDE_LINKS.forEach((guide) => {
+        const featureText = strings.features[guide.key];
+        if (!featureText) return;
+
+        const lang = normalizeLang(state.lang);
+        const langLinks = guide.links[lang] || guide.links.ja;
+
+        const col = document.createElement('div');
+        col.className = 'col';
+
+        const card = document.createElement('article');
+        card.className = 'card kesson-card h-100 reports-feature-card';
+        card.setAttribute('role', 'button');
+        card.setAttribute('tabindex', '0');
+        card.setAttribute('aria-label', `${featureText.title} ${strings.featureRead}`);
+
+        const body = document.createElement('div');
+        body.className = 'card-body p-2 p-md-3 d-flex flex-column gap-1';
+
+        const title = document.createElement('h3');
+        title.className = 'h6 mb-1 text-light';
+        title.textContent = featureText.title;
+
+        const desc = document.createElement('p');
+        desc.className = 'small mb-0 reports-feature-description';
+        desc.textContent = featureText.description;
+        body.appendChild(title);
+        body.appendChild(desc);
+        card.appendChild(body);
+
+        const openCardModal = () => {
+            openMarkdownModal({
+                mdUrl: langLinks.mdUrl,
+                title: featureText.modalTitle || featureText.title,
+                pdfUrl: langLinks.pdfUrl,
+            });
+        };
+        card.addEventListener('click', openCardModal);
+        card.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                openCardModal();
+            }
+        });
+
+        col.appendChild(card);
+        fragment.appendChild(col);
+    });
+
+    state.dom.featureCards.appendChild(fragment);
+}
+
+function render() {
+    renderFeatureCards();
+    if (state.dom.mdCloseBtn) {
+        state.dom.mdCloseBtn.textContent = getStrings(state.lang).modalClose;
+    }
+}
+
+export function initGuides({ lang = 'ja' } = {}) {
+    cacheDom();
+    state.lang = normalizeLang(lang);
+
+    if (state.dom.mdOpenPdf) {
+        state.dom.mdOpenPdf.addEventListener('click', (event) => {
+            if (state.dom.mdOpenPdf?.classList.contains('disabled')) {
+                event.preventDefault();
+            }
+        });
+    }
+
+    render();
+}
+
+export function setGuidesLanguage(lang) {
+    state.lang = normalizeLang(lang);
+    render();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,7 @@ import { initScrollUI, refreshGuideLang, updateScrollUI } from './scroll-ui.js';
 import { initMouseTracking, updateMouseSmoothing } from './mouse-state.js';
 import { refreshArticlesLanguage } from './pages/articles-section.js';
 import { refreshCreationCardsLanguage } from './pages/creation-cards-section.js';
+import { initGuides, setGuidesLanguage } from './guides.js';
 import { createSdfEntity } from './sdf-entity.js';
 
 const DEV_MODE = new URLSearchParams(window.location.search).has('dev');
@@ -47,6 +48,7 @@ const {
 initControls(camera, container, renderer);
 initNavigation({ scene, camera, renderer, xLogoGroup: xLogo.group, xLogoCamera: xLogo.camera });
 initScrollUI();
+initGuides({ lang: detectLang() });
 
 const sdfEntity = createSdfEntity();
 sdfEntity.mesh.visible = Boolean(toggles.sdfEntity);
@@ -80,6 +82,7 @@ initLanguageListeners({
     refreshDevlogLanguage,
     refreshArticlesLanguage,
     refreshCreationCardsLanguage,
+    refreshGuidesLanguage: () => setGuidesLanguage(detectLang()),
 });
 
 const clock = new THREE.Clock();

--- a/src/main/page-language.js
+++ b/src/main/page-language.js
@@ -52,6 +52,7 @@ export function initLanguageListeners({
     refreshDevlogLanguage = () => {},
     refreshArticlesLanguage = () => {},
     refreshCreationCardsLanguage = () => {},
+    refreshGuidesLanguage = () => {},
 } = {}) {
     window.addEventListener(LANG_CHANGE_EVENT, (event) => {
         const nextLang = event.detail?.lang || detectLang();
@@ -61,5 +62,6 @@ export function initLanguageListeners({
         refreshDevlogLanguage();
         refreshArticlesLanguage();
         refreshCreationCardsLanguage();
+        refreshGuidesLanguage();
     });
 }


### PR DESCRIPTION
## Summary
- `src/guides.js` 新規作成（creation-space/src/reports.js の MODEL_GUIDE_LINKS パターン準拠）
- `index.html` に GUIDES セクション + MD モーダル追加
- `main.js` / `page-language.js` に言語切替接続

## 対応内容
- kesson general / designer / academic の3種カード表示
- カードクリックで raw.githubusercontent 経由の MD をモーダル表示
- PDF ボタンで GitHub Pages 上の PDF を開く
- JA/EN 言語切替対応

## Test plan
- [ ] ローカルサーバーで GUIDES セクション表示確認
- [ ] カード3枚（一般向け / 設計者向け / 専門家向け）表示
- [ ] クリックでモーダルが開き MD が表示される
- [ ] PDF ボタンが機能する
- [ ] JA/EN 切替が動く

Generated with [Claude Code](https://claude.com/claude-code)