### PR TITLE
feat(typography): A-/A/A+ font size ctrl (#114)

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,13 @@
               DEVLOG
             </button>
           </li>
+          <li class="nav-item">
+            <div class="btn-group btn-group-sm topbar-font-size-ctrl" role="group" aria-label="文字サイズ調整">
+              <button type="button" class="btn topbar-font-btn" id="font-size-down" aria-label="文字を小さく">A-</button>
+              <button type="button" class="btn topbar-font-btn" id="font-size-label" disabled>文字: +0</button>
+              <button type="button" class="btn topbar-font-btn" id="font-size-up" aria-label="文字を大きく">A+</button>
+            </div>
+          </li>
           <li class="nav-item topbar-lang-item">
             <button type="button"
                     id="lang-toggle"

--- a/src/font-size-ctrl.js
+++ b/src/font-size-ctrl.js
@@ -1,0 +1,63 @@
+// font-size-ctrl.js
+// CHANGED(2026-03-07): #114 — フォントサイズステップ制御 (-1〜+4, 1step = +0.1rem)
+
+const STEP_REM = 0.1;
+const MIN_STEP = -1;
+const MAX_STEP = 4;
+const STORAGE_KEY = 'kesson-font-step';
+
+// 変更対象の CSS 変数と基底値のマップ
+const FONT_VARS = {
+  '--kesson-font-size-ui-xs': 0.65,
+  '--kesson-font-size-ui-sm': 0.70,
+};
+
+// 直接指定クラスの基底値 (rem)
+const CLASS_VARS = {
+  '--ks-section-heading': 0.75,
+  '--ks-card-title': 0.80,
+  '--ks-card-text': 0.70,
+  '--ks-card-summary': 0.68,
+};
+
+export function initFontSizeCtrl() {
+  const step = parseInt(localStorage.getItem(STORAGE_KEY) ?? '0', 10);
+  applyStep(step);
+
+  document.getElementById('font-size-down')?.addEventListener('click', () => {
+    const cur = getCurrentStep();
+    if (cur > MIN_STEP) setStep(cur - 1);
+  });
+  document.getElementById('font-size-up')?.addEventListener('click', () => {
+    const cur = getCurrentStep();
+    if (cur < MAX_STEP) setStep(cur + 1);
+  });
+}
+
+function getCurrentStep() {
+  return parseInt(localStorage.getItem(STORAGE_KEY) ?? '0', 10);
+}
+
+function setStep(step) {
+  localStorage.setItem(STORAGE_KEY, String(step));
+  applyStep(step);
+}
+
+function applyStep(step) {
+  const root = document.documentElement;
+
+  for (const [varName, base] of Object.entries(FONT_VARS)) {
+    root.style.setProperty(varName, `${(base + step * STEP_REM).toFixed(2)}rem`);
+  }
+  for (const [varName, base] of Object.entries(CLASS_VARS)) {
+    root.style.setProperty(varName, `${(base + step * STEP_REM).toFixed(2)}rem`);
+  }
+
+  const label = document.getElementById('font-size-label');
+  if (label) label.textContent = `文字: ${step >= 0 ? '+' : ''}${step}`;
+
+  const down = document.getElementById('font-size-down');
+  const up = document.getElementById('font-size-up');
+  if (down) down.disabled = step <= MIN_STEP;
+  if (up) up.disabled = step >= MAX_STEP;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ import { refreshDevlogLanguage } from './devlog/devlog.js';
 import { initLangToggle } from './lang-toggle.js';
 import { initMobileNavAutoCollapse } from './main/mobile-nav.js';
 import { initTopbarConsole } from './topbar-console.js';
+import { initFontSizeCtrl } from './font-size-ctrl.js';
 import { detectLang } from './i18n.js';
 import { breathConfig, liquidParams, toggles } from './config.js';
 import { initScrollUI, refreshGuideLang, updateScrollUI } from './scroll-ui.js';
@@ -33,6 +34,7 @@ applyPageLanguage(detectLang());
 initLangToggle();
 initMobileNavAutoCollapse();
 initTopbarConsole();
+initFontSizeCtrl();
 
 const container = document.getElementById('canvas-container');
 const {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -684,9 +684,10 @@
     #devlog-gallery-header.is-visible {
       opacity: 1;
     }
+    /* CHANGED(2026-03-07): #114 — CSS変数化で font-size-ctrl から可変 */
     #devlog-gallery-header h2,
     .section-heading {
-      font-size: 0.75rem;
+      font-size: var(--ks-section-heading, 0.75rem);
       font-weight: 400;
       color: var(--kesson-action-text);
       letter-spacing: var(--kesson-letter-ui-heading);
@@ -784,21 +785,22 @@
       aspect-ratio: 16/9;
       object-fit: cover;
     }
+    /* CHANGED(2026-03-07): #114 — CSS変数化で font-size-ctrl から可変 */
     .kesson-card .card-title {
       color: #fff;
-      font-size: 0.8rem;
+      font-size: var(--ks-card-title, 0.8rem);
     }
     .kesson-card .card-body small {
       color: rgba(var(--color-heading), 0.5);
-      font-size: 0.7rem;
+      font-size: var(--ks-card-text, 0.7rem);
     }
     .kesson-card .card-text {
       color: rgba(var(--color-heading), 0.5);
-      font-size: 0.7rem;
+      font-size: var(--ks-card-text, 0.7rem);
     }
     .kesson-card .kesson-card-summary {
       color: rgba(var(--color-sub-text), 0.76);
-      font-size: 0.68rem;
+      font-size: var(--ks-card-summary, 0.68rem);
       line-height: 1.45;
       display: -webkit-box;
       -webkit-box-orient: vertical;
@@ -1325,6 +1327,29 @@
       flex-shrink: 0;
     }
     /* CHANGED(2026-03-06): #105 — modal タイトル */
+    /* CHANGED(2026-03-07): #114 — font-size-ctrl topbar ボタン */
+    .topbar-font-size-ctrl {
+      opacity: 0.75;
+    }
+    .topbar-font-btn {
+      font-family: var(--kesson-font-mono-ui);
+      font-size: 0.6rem;
+      letter-spacing: 0.08em;
+      padding: 0.2rem 0.5rem;
+      background: transparent;
+      border: 1px solid rgba(130, 170, 240, 0.2);
+      color: rgba(205, 220, 244, 0.7);
+      line-height: 1.4;
+    }
+    .topbar-font-btn:hover:not(:disabled) {
+      background: rgba(120, 165, 240, 0.15);
+      color: rgba(236, 244, 255, 0.9);
+    }
+    .topbar-font-btn:disabled {
+      opacity: 0.3;
+      cursor: default;
+    }
+
     .viewer-title {
       flex: 1;
       font-size: 0.82rem;


### PR DESCRIPTION
kesson-space #114 の実装。

- `src/font-size-ctrl.js` 新規: ステップ制御ロジック（-1〜+4, 0.1rem刻み）
- `src/styles/main.css`: section-heading / card-title / card-text / card-summary を CSS変数化 + topbar ボタンスタイル追加
- `index.html`: topbar に A- / A+ ボタン追加
- `src/main.js`: import + initFontSizeCtrl() 呼び出し追加

localStorage でステップ保持。目視でジャストサイズを決めた後 main.css に確定値をコミット予定。