### PR TITLE
fix(guides): UIラベル「一般向け」→「概要版」(#116 Bug #2)

### DIFF
--- a/src/guides.js
+++ b/src/guides.js
@@ -64,7 +64,7 @@ const STRINGS = {
         modalGenerated: '生成日',
         features: {
             general: {
-                title: '一般向け',
+                title: '概要版',
                 modalTitle: '欠損駆動思考 — 概要版',
                 description: '欠損駆動思考の全体像を短く把握するための解説。',
             },


### PR DESCRIPTION
## Summary
- `guides.js` の `STRINGS.ja.features.general.title` を `一般向け` → `概要版` に変更
- 「設計者向け」「専門家向け」との格（機能分類ラベル）を統一
- `modalTitle`（`欠損駆動思考 — 概要版`）とも一致

## Test plan
- [ ] localhost:3001 で GUIDES セクションのカード表示が「概要版」になっている
- [ ] モーダルタイトルとの整合確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)