### PR TITLE
fix(guides): GUIDES カードスタイルを ARTICLES と統一 (#116 Bug #6)

### DIFF
--- a/src/guides.js
+++ b/src/guides.js
@@ -321,11 +321,12 @@ function renderFeatureCards() {
         body.className = 'card-body p-2 p-md-3 d-flex flex-column gap-1';
 
         const title = document.createElement('h3');
-        title.className = 'h6 mb-1 text-light';
+        // CHANGED(2026-03-07): #116 Bug #6 — ARTICLES カードと同じ card-title スタイルに統一
+        title.className = 'card-title mb-1';
         title.textContent = featureText.title;
 
         const desc = document.createElement('p');
-        desc.className = 'small mb-0 reports-feature-description';
+        desc.className = 'card-text mb-0';
         desc.textContent = featureText.description;
         body.appendChild(title);
         body.appendChild(desc);


### PR DESCRIPTION
## Summary
- GUIDES カードのタイトルクラスを `h6 text-light` → `card-title` に変更
- 説明クラスを `small reports-feature-description` → `card-text` に変更
- これにより `.kesson-card .card-title` / `.kesson-card .card-text` のスタイル（font-size, color）が ARTICLES カードと統一される

## 原因
guides.js のカード生成で Bootstrap の `h6` + `text-light` を直接使っていたため、`.kesson-card .card-title` のスタイルが適用されていなかった。

## Test plan
- [ ] localhost で GUIDES カードと ARTICLES カードの文字スタイルが揃っていること
- [ ] font-size-ctrl (A+/A-) で GUIDES カードも連動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)