### PR TITLE
fix(typography): surface ボタン連動 + デフォルト +3 ステップ (#116 Bug #8+#9)

### DIFF
--- a/src/font-size-ctrl.js
+++ b/src/font-size-ctrl.js
@@ -2,8 +2,10 @@
 // CHANGED(2026-03-07): #114 — フォントサイズステップ制御 (-1〜+4, 1step = +0.1rem)
 
 const STEP_REM = 0.1;
+// CHANGED(2026-03-07): #116 Bug #9 — デフォルト +3, レンジ拡張
+const DEFAULT_STEP = 3;
 const MIN_STEP = -1;
-const MAX_STEP = 4;
+const MAX_STEP = 7;
 const STORAGE_KEY = 'kesson-font-step';
 
 // 変更対象の CSS 変数と基底値のマップ
@@ -23,10 +25,11 @@ const CLASS_VARS = {
   '--ks-overlay-tagline-en': 0.48,
   '--ks-control-guide':      0.45,
   '--ks-footer-line':        0.45,
+  '--ks-surface-btn':        0.55,
 };
 
 export function initFontSizeCtrl() {
-  const step = parseInt(localStorage.getItem(STORAGE_KEY) ?? '0', 10);
+  const step = parseInt(localStorage.getItem(STORAGE_KEY) ?? String(DEFAULT_STEP), 10);
   applyStep(step);
 
   document.getElementById('font-size-down')?.addEventListener('click', () => {
@@ -38,12 +41,12 @@ export function initFontSizeCtrl() {
     if (cur < MAX_STEP) setStep(cur + 1);
   });
   document.getElementById('font-size-reset')?.addEventListener('click', () => {
-    setStep(0);
+    setStep(DEFAULT_STEP);
   });
 }
 
 function getCurrentStep() {
-  return parseInt(localStorage.getItem(STORAGE_KEY) ?? '0', 10);
+  return parseInt(localStorage.getItem(STORAGE_KEY) ?? String(DEFAULT_STEP), 10);
 }
 
 function setStep(step) {
@@ -66,5 +69,5 @@ function applyStep(step) {
   const reset = document.getElementById('font-size-reset');
   if (down)  down.disabled  = step <= MIN_STEP;
   if (up)    up.disabled    = step >= MAX_STEP;
-  if (reset) reset.disabled = step === 0;
+  if (reset) reset.disabled = step === DEFAULT_STEP;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -435,7 +435,7 @@
 
     /* CHANGED(2026-03-07): #114 — CSS変数化で font-size-ctrl から可変（clamp はフォールバック） */
     .tagline {
-      font-size: var(--ks-overlay-tagline, clamp(0.5rem, 2.4vmin, 0.85rem));
+      font-size: var(--ks-overlay-tagline, 0.85rem);
       color: rgba(var(--color-heading), 0.75);
       font-family: "Noto Serif JP", "Yu Mincho", "MS PMincho", serif;
       letter-spacing: 0.05em;
@@ -444,7 +444,7 @@
     }
 
     .tagline-en {
-      font-size: var(--ks-overlay-tagline-en, clamp(0.4rem, 2.0vmin, 0.75rem));
+      font-size: var(--ks-overlay-tagline-en, 0.78rem);
       color: rgba(var(--color-heading), 0.55);
       font-family: var(--kesson-font-serif-ui);
       letter-spacing: 0.03em;
@@ -634,7 +634,7 @@
     }
     /* CHANGED(2026-03-07): #114 — CSS変数化で font-size-ctrl から可変（clamp はフォールバック） */
     #control-guide .guide-key {
-      font-size: var(--ks-control-guide, clamp(0.35rem, 1.6vmin, 0.55rem));
+      font-size: var(--ks-control-guide, 0.75rem);
       color: rgba(var(--color-sub-text), 0.35);
       font-family: var(--kesson-font-mono-ui);
       letter-spacing: var(--kesson-letter-ui-tight);
@@ -645,7 +645,7 @@
       color: rgba(var(--color-sub-text), 0.2);
     }
     #control-guide .guide-action {
-      font-size: var(--ks-control-guide, clamp(0.35rem, 1.6vmin, 0.55rem));
+      font-size: var(--ks-control-guide, 0.75rem);
       color: rgba(var(--color-sub-text), 0.3);
       font-family: var(--kesson-font-serif-ui);
       letter-spacing: var(--kesson-letter-ui-normal);
@@ -694,7 +694,8 @@
     /* CHANGED(2026-03-07): #114 — CSS変数化で font-size-ctrl から可変 */
     #devlog-gallery-header h2,
     .section-heading {
-      font-size: var(--ks-section-heading, 0.75rem);
+      /* CHANGED(2026-03-07): #116 Bug #9 — デフォルト +3 step (0.75+0.3=1.05) */
+      font-size: var(--ks-section-heading, 1.05rem);
       font-weight: 400;
       color: var(--kesson-action-text);
       letter-spacing: var(--kesson-letter-ui-heading);
@@ -795,19 +796,19 @@
     /* CHANGED(2026-03-07): #114 — CSS変数化で font-size-ctrl から可変 */
     .kesson-card .card-title {
       color: #fff;
-      font-size: var(--ks-card-title, 0.8rem);
+      font-size: var(--ks-card-title, 1.1rem);
     }
     .kesson-card .card-body small {
       color: rgba(var(--color-heading), 0.5);
-      font-size: var(--ks-card-text, 0.7rem);
+      font-size: var(--ks-card-text, 1.0rem);
     }
     .kesson-card .card-text {
       color: rgba(var(--color-heading), 0.5);
-      font-size: var(--ks-card-text, 0.7rem);
+      font-size: var(--ks-card-text, 1.0rem);
     }
     .kesson-card .kesson-card-summary {
       color: rgba(var(--color-sub-text), 0.76);
-      font-size: var(--ks-card-summary, 0.68rem);
+      font-size: var(--ks-card-summary, 0.98rem);
       line-height: 1.45;
       display: -webkit-box;
       -webkit-box-orient: vertical;
@@ -834,7 +835,8 @@
       bottom: 24px;
       right: 24px;
       z-index: 20;
-      font-size: clamp(0.45rem, 2.0vmin, 0.7rem);
+      /* CHANGED(2026-03-07): #116 Bug #8 — font-size-ctrl 連動 */
+      font-size: var(--ks-surface-btn, 0.85rem);
       letter-spacing: var(--kesson-letter-ui-wide);
       padding: 10px 18px;
       opacity: 0;
@@ -1677,7 +1679,7 @@
     }
     /* CHANGED(2026-03-07): #114 — CSS変数化で font-size-ctrl から可変（clamp はフォールバック） */
     .tech-footer-line {
-      font-size: var(--ks-footer-line, clamp(0.35rem, 1.5vmin, 0.55rem));
+      font-size: var(--ks-footer-line, 0.75rem);
       color: rgba(150, 175, 210, 0.25);
       font-family: var(--kesson-font-mono-ui);
       letter-spacing: 0.06em;


### PR DESCRIPTION
## Summary
### Bug #8: surface ボタンが font-size-ctrl 非連動
- `#surface-btn` の `font-size` を `clamp(...)` → `var(--ks-surface-btn)` に変更
- `font-size-ctrl.js` の `CLASS_VARS` に `--ks-surface-btn` を追加

### Bug #9: デフォルトフォントサイズを +3 ステップに
- `DEFAULT_STEP = 3`（旧: 0）
- レンジ: MIN -1 / MAX 7（旧: -1 / 4）
- CSS デフォルト値を +3 step 相当に更新（JS適用前のちらつき防止）
- リセットボタンは新デフォルト（3）に戻す

## Test plan
- [ ] localhost で A-/↺/A+ が動作し、初期表示が +3 相当
- [ ] ↺ で step=3 にリセットされる
- [ ] surface ボタンの文字サイズが A+/A- に連動
- [ ] localStorage クリア後のリロードで +3 が適用される

🤖 Generated with [Claude Code](https://claude.com/claude-code)