### PR TITLE
fix: Bug #10・#11 フォントサイズ修正（topbar subtitle / tagline migration）(#116)

### DIFF
--- a/src/font-size-ctrl.js
+++ b/src/font-size-ctrl.js
@@ -7,6 +7,7 @@ const DEFAULT_STEP = 3;
 const MIN_STEP = -1;
 const MAX_STEP = 7;
 const STORAGE_KEY = 'kesson-font-step';
+const MIGRATION_KEY = 'kesson-font-step-v2';
 
 // 変更対象の CSS 変数と基底値のマップ
 const FONT_VARS = {
@@ -29,6 +30,14 @@ const CLASS_VARS = {
 };
 
 export function initFontSizeCtrl() {
+  // CHANGED(2026-03-07): #116 Bug #11 — 旧デフォルト(0)→新デフォルト(3)の一度きり移行
+  if (!localStorage.getItem(MIGRATION_KEY)) {
+    const old = localStorage.getItem(STORAGE_KEY);
+    if (old === '0' || old === null) {
+      localStorage.setItem(STORAGE_KEY, String(DEFAULT_STEP));
+    }
+    localStorage.setItem(MIGRATION_KEY, '1');
+  }
   const step = parseInt(localStorage.getItem(STORAGE_KEY) ?? String(DEFAULT_STEP), 10);
   applyStep(step);
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -239,11 +239,11 @@
       padding-left: 0.55rem;
       border-left: 1px solid rgba(130, 170, 240, 0.2);
     }
-    /* CHANGED(2026-03-07): #116 — clamp min 0.58rem → 0.64rem */
+    /* CHANGED(2026-03-07): #116 Bug #10 — topbar-link と同サイズ (0.80rem) に統一 */
     #kesson-topbar .topbar-collab-note {
       display: inline-block;
       font-family: var(--kesson-font-serif-ui);
-      font-size: clamp(0.64rem, 0.82vw, 0.72rem);
+      font-size: 0.80rem;
       line-height: 1;
       letter-spacing: 0.06em;
       color: rgba(165, 214, 255, 0.74);


### PR DESCRIPTION
## Summary
### Bug #10: 左上サブタイトルのフォントサイズ統一
- `.topbar-collab-note` を `clamp(0.64rem, 0.82vw, 0.72rem)` → `0.80rem` に変更
- `.topbar-link` (0.80rem) と統一

### Bug #11: 左下テキスト（tagline）が小さくなっていた問題
- 原因: Bug #9 で DEFAULT_STEP を 0→3 に変更したが、既存ユーザーの localStorage に旧 step=0 が残っていた
- 修正: `kesson-font-step-v2` マイグレーションキーで一度きりの移行処理を追加
  - localStorage に step=0 または未設定の場合 → step=3（新デフォルト）に更新

## Test plan
- [ ] Bug #10: 左上「AIとの協働で探索中」が topbar ナビリンクと同サイズ
- [ ] Bug #11: localStorage クリア後に tagline が +3 相当で表示される
- [ ] Bug #11: 旧 step=0 保存状態でリロードすると step=3 に移行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)