### PR TITLE
fix(typography): keep topbar nav at token default

### DIFF
--- a/src/font-size-ctrl.js
+++ b/src/font-size-ctrl.js
@@ -30,8 +30,7 @@ const CLASS_VARS = {
   '--ks-card-title':         0.80,
   '--ks-card-text':          0.70,
   '--ks-card-summary':       0.68,
-  '--ks-topbar-link-size':   0.80,
-  '--ks-topbar-note-size':   0.80,
+  // Keep topbar menu typography on static theme tokens; issue #122's +3 default made it too large.
   // navi 以外の追加対象
   '--ks-overlay-tagline':    0.85,
   '--ks-overlay-tagline-en': 0.78,

--- a/tests/config-consistency.test.js
+++ b/tests/config-consistency.test.js
@@ -138,8 +138,10 @@ assert(/export\s+function\s+getCurrentStep/.test(fontSizeCtrlSrc), 'font-size-ct
 assert(/export\s+function\s+setStep/.test(fontSizeCtrlSrc), 'font-size-ctrl: setStep を export している');
 assert(/'--ks-overlay-tagline':\s*0\.85/.test(fontSizeCtrlSrc), 'font-size-ctrl: overlay tagline 基底値が 0.85');
 assert(/'--ks-overlay-tagline-en':\s*0\.78/.test(fontSizeCtrlSrc), 'font-size-ctrl: overlay tagline en 基底値が 0.78');
-assert(/'--ks-topbar-link-size':\s*0\.80/.test(fontSizeCtrlSrc), 'font-size-ctrl: topbar link サイズを制御する');
-assert(/'--ks-topbar-note-size':\s*0\.80/.test(fontSizeCtrlSrc), 'font-size-ctrl: topbar collab note サイズを制御する');
+assert(!/'--ks-topbar-link-size':\s*0\.80/.test(fontSizeCtrlSrc), 'font-size-ctrl: topbar link サイズは制御しない');
+assert(!/'--ks-topbar-note-size':\s*0\.80/.test(fontSizeCtrlSrc), 'font-size-ctrl: topbar collab note サイズは制御しない');
+assert(/--ks-topbar-link-size:\s*0\.80rem;/.test(read(resolve(SRC, 'styles', 'main.css'))), 'main.css: topbar link サイズの既定値を持つ');
+assert(/--ks-topbar-note-size:\s*0\.80rem;/.test(read(resolve(SRC, 'styles', 'main.css'))), 'main.css: topbar collab note サイズの既定値を持つ');
 
 section('2.6. dev bootstrap fallback');
 


### PR DESCRIPTION
Summary
- remove topbar nav font-size tokens from font-size-ctrl.js so the global +3 default step no longer enlarges the menu
- keep navigation/menu typography on the static theme tokens defined in src/styles/main.css
- update config consistency coverage so topbar nav sizing stays out of step-controlled variables

Changed
- src/font-size-ctrl.js
- tests/config-consistency.test.js

Test plan
- node tests/config-consistency.test.js
- npm run test:devlog-nav
- node --check src/font-size-ctrl.js
- git diff --check
- visual check completed on local preview