### PR TITLE
fix: update Gemini image model to 2.5-flash

### DIFF
--- a/mcp_servers/gemini_threejs.py
+++ b/mcp_servers/gemini_threejs.py
@@ -428,7 +428,7 @@ def list_models() -> str:
 IMAGE_OUTPUT_DIR = Path(__file__).parent.parent / "generated_images"
 
 # 画像生成モデル
-IMAGE_MODEL = "gemini-2.0-flash-exp-image-generation"
+IMAGE_MODEL = "gemini-2.5-flash-image"
 IMAGE_COST_PER_CALL = 0.5  # 円/回（推定）
 
 


### PR DESCRIPTION
## Summary
- 画像生成モデルを `gemini-2.0-flash-exp-image-generation` → `gemini-2.5-flash-image` に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)