### PR TITLE
feat: port rich-slides pipeline from creation-space (#144)

### DIFF
--- a/content/guides/meta-overview.html
+++ b/content/guides/meta-overview.html
@@ -1,0 +1,689 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>欠損駆動思考 — 全体像</title>
+<style>
+  /* === RESET & BASE === */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Noto+Sans+JP:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+  :root {
+    --bg-deep: #0a0e17;
+    --bg-elevated: #1e293b;
+    --bg-card: rgba(17, 24, 39, 0.74);
+    --text-primary: #f1f5f9;
+    --text-secondary: #94a3b8;
+    --text-tertiary: #64748b;
+    --accent-blue: #60a5fa;
+    --accent-violet: #a78bfa;
+    --accent-green: #34d399;
+    --accent-amber: #fbbf24;
+    --glass-bg: rgba(17, 24, 39, 0.74);
+    --glass-border: rgba(148, 163, 184, 0.14);
+    --glass-blur: 16px;
+    --font-heading: "Inter", "Noto Sans JP", system-ui, sans-serif;
+    --font-body: "Inter", "Noto Sans JP", system-ui, sans-serif;
+    --font-mono: "JetBrains Mono", "Fira Code", monospace;
+    --radius: 16px;
+    --radius-sm: 8px;
+    --transition: 280ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  html, body {
+    width: 100%; height: 100%;
+    background: var(--bg-deep);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    overflow: hidden;
+  }
+
+  /* === DECK CONTAINER === */
+  .deck {
+    width: 100vw; height: 100vh;
+    position: relative;
+    overflow: hidden;
+  }
+
+  /* === SLIDE === */
+  .slide {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--transition), visibility var(--transition);
+  }
+  .slide.active {
+    opacity: 1;
+    visibility: visible;
+  }
+  .slide-inner {
+    width: min(92vw, calc(88vh * 16 / 9));
+    aspect-ratio: 16 / 9;
+    border-radius: var(--radius);
+    border: 1px solid var(--glass-border);
+    overflow: hidden;
+    position: relative;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+  }
+
+  /* === AMBIENT GRADIENTS === */
+  .slide-bg {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+  .slide-bg--blue {
+    background:
+      radial-gradient(ellipse at 18% 40%, rgba(96, 165, 250, 0.10), transparent 50%),
+      radial-gradient(ellipse at 82% 20%, rgba(167, 139, 250, 0.08), transparent 40%),
+      linear-gradient(180deg, #0c1220, #0a0e17);
+  }
+  .slide-bg--violet {
+    background:
+      radial-gradient(ellipse at 70% 30%, rgba(167, 139, 250, 0.12), transparent 50%),
+      radial-gradient(ellipse at 20% 70%, rgba(96, 165, 250, 0.06), transparent 40%),
+      linear-gradient(180deg, #0e0c20, #0a0e17);
+  }
+  .slide-bg--green {
+    background:
+      radial-gradient(ellipse at 50% 40%, rgba(52, 211, 153, 0.10), transparent 50%),
+      radial-gradient(ellipse at 80% 80%, rgba(96, 165, 250, 0.06), transparent 40%),
+      linear-gradient(180deg, #0a1218, #0a0e17);
+  }
+  .slide-bg--amber {
+    background:
+      radial-gradient(ellipse at 30% 30%, rgba(251, 191, 36, 0.08), transparent 50%),
+      radial-gradient(ellipse at 75% 60%, rgba(167, 139, 250, 0.06), transparent 40%),
+      linear-gradient(180deg, #12100a, #0a0e17);
+  }
+
+  /* === SLIDE CONTENT AREA === */
+  .slide-content {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    padding: 3.5rem 4rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* === TYPOGRAPHY === */
+  h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(2rem, 3.2vw, 3rem);
+    font-weight: 700;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+  }
+  h2 {
+    font-family: var(--font-heading);
+    font-size: clamp(1.4rem, 2.2vw, 2rem);
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    margin-bottom: 1.2rem;
+  }
+  h3 {
+    font-family: var(--font-heading);
+    font-size: clamp(1rem, 1.4vw, 1.3rem);
+    font-weight: 500;
+    color: var(--accent-violet);
+    margin-bottom: 0.8rem;
+  }
+  p {
+    font-size: clamp(0.9rem, 1.2vw, 1.1rem);
+    line-height: 1.8;
+    color: var(--text-primary);
+    margin-bottom: 0.8rem;
+  }
+  .text-muted { color: var(--text-secondary); }
+  .text-accent-blue { color: var(--accent-blue); }
+  .text-accent-violet { color: var(--accent-violet); }
+  .text-accent-green { color: var(--accent-green); }
+
+  /* === ACCENT LINE === */
+  .accent-line {
+    width: 80px;
+    height: 3px;
+    border-radius: 2px;
+    background: linear-gradient(90deg, var(--accent-blue), var(--accent-violet));
+    margin: 1rem 0;
+  }
+  .accent-line--center { margin: 1rem auto; }
+  .accent-line--green {
+    background: linear-gradient(90deg, var(--accent-green), transparent);
+  }
+
+  /* === GLASS CARD === */
+  .glass-card {
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius);
+    padding: 1.5rem 2rem;
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+  }
+  .glass-card--accent-left {
+    border-left: 3px solid var(--accent-blue);
+  }
+  .glass-card--glow {
+    box-shadow: 0 0 30px rgba(96, 165, 250, 0.08),
+                0 8px 32px rgba(0, 0, 0, 0.3);
+  }
+
+  /* === METRIC BOX === */
+  .metric-box {
+    text-align: center;
+    padding: 1.5rem;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius);
+    backdrop-filter: blur(var(--glass-blur));
+  }
+  .metric-value {
+    font-family: var(--font-mono);
+    font-size: clamp(2rem, 3.5vw, 3.2rem);
+    font-weight: 700;
+    background: linear-gradient(135deg, var(--accent-blue), var(--accent-violet));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .metric-label {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-top: 0.4rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  /* === TABLE === */
+  table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    font-size: 0.9rem;
+  }
+  th {
+    padding: 0.8rem 1.2rem;
+    background: var(--bg-elevated);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+    text-align: left;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  td {
+    padding: 0.7rem 1.2rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.06);
+  }
+  tr:last-child td { border-bottom: none; }
+
+  /* === CODE BLOCK === */
+  pre {
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(148, 163, 184, 0.08);
+    border-radius: var(--radius-sm);
+    padding: 1.2rem 1.5rem;
+    overflow-x: auto;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    line-height: 1.7;
+    color: var(--accent-green);
+  }
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    background: rgba(52, 211, 153, 0.08);
+    color: var(--accent-green);
+  }
+  pre code { padding: 0; background: none; }
+
+  /* === BLOCKQUOTE === */
+  blockquote {
+    padding: 1.5rem 2rem;
+    border-left: 3px solid var(--accent-blue);
+    background: rgba(17, 24, 39, 0.6);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    border: 1px solid var(--glass-border);
+    border-left: 3px solid var(--accent-blue);
+    font-size: 1.15rem;
+    line-height: 1.7;
+    font-style: italic;
+    color: var(--text-secondary);
+  }
+  blockquote strong { color: var(--accent-blue); font-style: normal; }
+
+  /* === LIST === */
+  ul, ol {
+    padding-left: 0;
+    list-style: none;
+  }
+  ul li, ol li {
+    padding: 0.5rem 0 0.5rem 1.5rem;
+    position: relative;
+    line-height: 1.7;
+  }
+  ul li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 1rem;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent-blue);
+  }
+  ol { counter-reset: slide-ol; }
+  ol li { counter-increment: slide-ol; }
+  ol li::before {
+    content: counter(slide-ol);
+    position: absolute;
+    left: 0;
+    top: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--accent-violet);
+    font-weight: 600;
+  }
+
+  /* ======================= */
+  /* === LAYOUT VARIANTS === */
+  /* ======================= */
+
+  /* --- TITLE SLIDE --- */
+  .layout-title .slide-content {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 0.5rem;
+  }
+  .layout-title h1 {
+    font-size: clamp(2.4rem, 4vw, 3.6rem);
+    font-weight: 700;
+    max-width: 80%;
+  }
+  .layout-title .subtitle {
+    font-size: clamp(1rem, 1.5vw, 1.3rem);
+    color: var(--text-secondary);
+    letter-spacing: 0.04em;
+    max-width: 70%;
+  }
+  .layout-title .meta {
+    font-size: 0.85rem;
+    color: var(--text-tertiary);
+    margin-top: 1rem;
+    font-family: var(--font-mono);
+    letter-spacing: 0.06em;
+  }
+
+  /* --- SECTION DIVIDER --- */
+  .layout-section .slide-content {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+  .layout-section h2 {
+    font-size: clamp(2rem, 3vw, 2.8rem);
+    font-weight: 600;
+  }
+  .layout-section .section-number {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--accent-blue);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+  }
+
+  /* --- CONTENT SLIDE --- */
+  .layout-content .slide-content {
+    justify-content: flex-start;
+    gap: 1rem;
+  }
+  .layout-content .body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+
+  /* --- SPLIT SLIDE (two columns) --- */
+  .layout-split .slide-content {
+    gap: 1rem;
+  }
+  .split-columns {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: start;
+  }
+  .split-col {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+  .split-divider {
+    width: 1px;
+    align-self: stretch;
+    background: linear-gradient(180deg, transparent, var(--glass-border), transparent);
+  }
+
+  /* --- DATA / METRICS SLIDE --- */
+  .layout-data .slide-content {
+    gap: 1.5rem;
+  }
+  .metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.2rem;
+    flex: 1;
+    align-content: center;
+  }
+
+  /* --- QUOTE SLIDE --- */
+  .layout-quote .slide-content {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 4rem 6rem;
+  }
+  .layout-quote blockquote {
+    border: none;
+    border-left: none;
+    background: none;
+    font-size: clamp(1.3rem, 2vw, 1.8rem);
+    line-height: 1.6;
+    max-width: 80%;
+    color: var(--text-primary);
+  }
+  .layout-quote .attribution {
+    font-size: 0.9rem;
+    color: var(--text-tertiary);
+    margin-top: 1.5rem;
+    font-style: normal;
+  }
+
+  /* --- VISUAL SLIDE (full image) --- */
+  .layout-visual .slide-content {
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 2rem 3rem;
+  }
+  .layout-visual img, .layout-visual svg {
+    max-width: 90%;
+    max-height: 70%;
+    border-radius: var(--radius);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  }
+
+  /* --- CONCLUSION SLIDE --- */
+  .layout-conclusion .slide-content {
+    gap: 1.2rem;
+  }
+  .layout-conclusion ul li::before {
+    background: var(--accent-green);
+    width: 8px;
+    height: 8px;
+  }
+
+  /* === ANIMATIONS === */
+  @keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .slide.active .animate-in {
+    animation: fadeInUp 0.4s cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+  .slide.active .delay-1 { animation-delay: 0.08s; }
+  .slide.active .delay-2 { animation-delay: 0.16s; }
+  .slide.active .delay-3 { animation-delay: 0.24s; }
+  .slide.active .delay-4 { animation-delay: 0.32s; }
+  .slide.active .delay-5 { animation-delay: 0.40s; }
+
+  /* === NAVIGATION === */
+  .nav-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 0.6rem 1rem;
+    background: rgba(10, 14, 23, 0.85);
+    backdrop-filter: blur(12px);
+    border-top: 1px solid var(--glass-border);
+  }
+  .nav-btn {
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    background: var(--glass-bg);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-transform: uppercase;
+  }
+  .nav-btn:hover { background: rgba(96, 165, 250, 0.12); border-color: rgba(96, 165, 250, 0.3); }
+  .nav-btn:disabled { opacity: 0.4; cursor: default; }
+  .nav-counter {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--text-tertiary);
+    min-width: 5rem;
+    text-align: center;
+  }
+  .nav-title {
+    font-family: var(--font-heading);
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    max-width: 40vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .nav-fullscreen {
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    background: var(--glass-bg);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: all 0.2s ease;
+  }
+  .nav-fullscreen:hover { color: var(--text-primary); background: rgba(96, 165, 250, 0.12); }
+
+  /* === PROGRESS BAR === */
+  .progress-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    height: 2px;
+    background: linear-gradient(90deg, var(--accent-blue), var(--accent-violet));
+    transition: width 0.3s ease;
+    z-index: 101;
+  }
+
+  /* === PRINT === */
+  @media print {
+    .nav-bar, .progress-bar { display: none; }
+    .slide {
+      position: relative;
+      opacity: 1;
+      visibility: visible;
+      page-break-after: always;
+      height: 100vh;
+    }
+    .slide-inner {
+      width: 100%;
+      box-shadow: none;
+      border: none;
+    }
+  }
+
+  /* === RESPONSIVE === */
+  @media (max-width: 768px) {
+    .slide-content { padding: 2rem 2.5rem; }
+    .layout-title h1 { font-size: 2rem; }
+    .split-columns { grid-template-columns: 1fr; }
+    .nav-title { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<div class="deck" id="deck">
+<div class="slide layout-title active">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--violet"></div>
+    <div class="slide-content">
+<h2 class="animate-in delay-1">欠損駆動思考</h2>
+<div class="accent-line animate-in delay-2"></div>
+<p class="animate-in delay-3">無意味さは、無意味なのか？</p>
+    </div>
+  </div>
+</div>
+<div class="slide layout-content">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--blue"></div>
+    <div class="slide-content">
+<h2 class="animate-in delay-1">出発点</h2>
+<div class="accent-line animate-in delay-2"></div>
+<p class="animate-in delay-3">棄却される誤差を、問いとして拾う。</p>
+<p class="animate-in delay-4">予想と現実のズレを「欠け」として感じること — それは創造の起点になる。</p>
+    </div>
+  </div>
+</div>
+<div class="slide layout-content">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--blue"></div>
+    <div class="slide-content">
+<h2 class="animate-in delay-1">概要</h2>
+<div class="accent-line animate-in delay-2"></div>
+<ul>
+<li class="animate-in delay-3"><strong>D1 + D2</strong>: 態度と経験は切り離せない</li>
+<li class="animate-in delay-4"><strong>D3</strong>: 反射的に処理せず、問いとして保持する</li>
+<li class="animate-in delay-5"><strong>D4</strong>: 生存（F軸）と愛（O軸）で評価され、情動として構成される</li>
+</ul>
+    </div>
+  </div>
+</div>
+<div class="slide layout-data">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--violet"></div>
+    <div class="slide-content">
+<h2 class="animate-in delay-1">これは創造的な構えである</h2>
+<div class="accent-line animate-in delay-2"></div>
+<p class="animate-in delay-3">30の学術領域を横断した調査が示すもの:</p>
+<table class="animate-in delay-4"><tr><th>テーマ</th><th>領域数</th></tr><tr><td>縁の類型学</td><td>28/30</td></tr><tr><td>再循環メカニズム</td><td>19/30</td></tr><tr><td>場の多層性</td><td>15/30</td></tr><tr><td>盲点と反例</td><td>13+11/30</td></tr><tr><td>閾値構造</td><td>11/30</td></tr></table>
+<blockquote class="animate-in delay-5">詳細 → creation-space</blockquote>
+    </div>
+  </div>
+</div>
+<div class="slide layout-quote">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--amber"></div>
+    <div class="slide-content">
+<h2 class="animate-in delay-1">気づきの構造</h2>
+<div class="accent-line animate-in delay-2"></div>
+<p class="animate-in delay-3">欠損（D2）と情動の構成（D4）の詳細は awareness-space に。</p>
+<blockquote class="animate-in delay-4">詳細 → awareness-space</blockquote>
+    </div>
+  </div>
+</div>
+<div class="slide layout-content">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--blue"></div>
+    <div class="slide-content">
+<h2 class="animate-in delay-1">3つのガイド</h2>
+<div class="accent-line animate-in delay-2"></div>
+<ul>
+<li class="animate-in delay-3"><strong>一般向け</strong> — 全体像を短く把握する</li>
+<li class="animate-in delay-4"><strong>設計者向け</strong> — 設計判断と運用視点で読む</li>
+<li class="animate-in delay-5"><strong>専門家向け</strong> — 理論比較と検証観点を含む</li>
+</ul>
+    </div>
+  </div>
+</div>
+<div class="slide layout-conclusion">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--green"></div>
+    <div class="slide-content">
+<h2 class="animate-in delay-1">まとめ</h2>
+<div class="accent-line accent-line--green animate-in delay-2"></div>
+<p class="animate-in delay-3">欠損は欠落ではない。</p>
+<p class="animate-in delay-4">創造の駆動力である。</p>
+    </div>
+  </div>
+</div>
+</div>
+
+<div class="nav-bar">
+  <button class="nav-btn" id="prevBtn" onclick="go(-1)">Prev</button>
+  <span class="nav-title" id="deckTitle">欠損駆動思考 — 全体像</span>
+  <span class="nav-counter" id="counter">1 / N</span>
+  <button class="nav-btn" id="nextBtn" onclick="go(1)">Next</button>
+  <button class="nav-fullscreen" onclick="toggleFS()" title="Fullscreen">&#x26F6;</button>
+</div>
+<div class="progress-bar" id="progress"></div>
+
+<script>
+  const slides = document.querySelectorAll('.slide');
+  let cur = 0;
+  function show(i) {
+    slides.forEach((s, idx) => s.classList.toggle('active', idx === i));
+    document.getElementById('counter').textContent = (i + 1) + ' / ' + slides.length;
+    document.getElementById('progress').style.width = ((i + 1) / slides.length * 100) + '%';
+    document.getElementById('prevBtn').disabled = i === 0;
+    document.getElementById('nextBtn').disabled = i === slides.length - 1;
+  }
+  function go(d) {
+    const next = Math.max(0, Math.min(slides.length - 1, cur + d));
+    if (next !== cur) { cur = next; show(cur); }
+  }
+  function toggleFS() {
+    if (!document.fullscreenElement) document.documentElement.requestFullscreen();
+    else document.exitFullscreen();
+  }
+  document.addEventListener('keydown', e => {
+    if (e.key === 'ArrowRight' || e.key === ' ' || e.key === 'PageDown') { e.preventDefault(); go(1); }
+    if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.preventDefault(); go(-1); }
+    if (e.key === 'f' || e.key === 'F') toggleFS();
+    if (e.key === 'Escape' && document.fullscreenElement) document.exitFullscreen();
+  });
+  // Touch swipe
+  let touchX = 0;
+  document.addEventListener('touchstart', e => { touchX = e.touches[0].clientX; });
+  document.addEventListener('touchend', e => {
+    const dx = e.changedTouches[0].clientX - touchX;
+    if (Math.abs(dx) > 50) go(dx < 0 ? 1 : -1);
+  });
+  show(0);
+</script>
+</body>
+</html>

--- a/docs/rich-slides-design-spec.md
+++ b/docs/rich-slides-design-spec.md
@@ -1,0 +1,766 @@
+# Rich Slides — Design Specification
+
+## HTML Shell
+
+Every generated slide deck uses this outer structure. All CSS and JS are inlined.
+
+```html
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{TITLE}}</title>
+<style>
+  /* === RESET & BASE === */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Noto+Sans+JP:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+  :root {
+    --bg-deep: #0a0e17;
+    --bg-elevated: #1e293b;
+    --bg-card: rgba(17, 24, 39, 0.74);
+    --text-primary: #f1f5f9;
+    --text-secondary: #94a3b8;
+    --text-tertiary: #64748b;
+    --accent-blue: #60a5fa;
+    --accent-violet: #a78bfa;
+    --accent-green: #34d399;
+    --accent-amber: #fbbf24;
+    --glass-bg: rgba(17, 24, 39, 0.74);
+    --glass-border: rgba(148, 163, 184, 0.14);
+    --glass-blur: 16px;
+    --font-heading: "Inter", "Noto Sans JP", system-ui, sans-serif;
+    --font-body: "Inter", "Noto Sans JP", system-ui, sans-serif;
+    --font-mono: "JetBrains Mono", "Fira Code", monospace;
+    --radius: 16px;
+    --radius-sm: 8px;
+    --transition: 280ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  html, body {
+    width: 100%; height: 100%;
+    background: var(--bg-deep);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    overflow: hidden;
+  }
+
+  /* === DECK CONTAINER === */
+  .deck {
+    width: 100vw; height: 100vh;
+    position: relative;
+    overflow: hidden;
+  }
+
+  /* === SLIDE === */
+  .slide {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--transition), visibility var(--transition);
+  }
+  .slide.active {
+    opacity: 1;
+    visibility: visible;
+  }
+  .slide-inner {
+    width: min(92vw, calc(88vh * 16 / 9));
+    aspect-ratio: 16 / 9;
+    border-radius: var(--radius);
+    border: 1px solid var(--glass-border);
+    overflow: hidden;
+    position: relative;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+  }
+
+  /* === AMBIENT GRADIENTS === */
+  .slide-bg {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+  .slide-bg--blue {
+    background:
+      radial-gradient(ellipse at 18% 40%, rgba(96, 165, 250, 0.10), transparent 50%),
+      radial-gradient(ellipse at 82% 20%, rgba(167, 139, 250, 0.08), transparent 40%),
+      linear-gradient(180deg, #0c1220, #0a0e17);
+  }
+  .slide-bg--violet {
+    background:
+      radial-gradient(ellipse at 70% 30%, rgba(167, 139, 250, 0.12), transparent 50%),
+      radial-gradient(ellipse at 20% 70%, rgba(96, 165, 250, 0.06), transparent 40%),
+      linear-gradient(180deg, #0e0c20, #0a0e17);
+  }
+  .slide-bg--green {
+    background:
+      radial-gradient(ellipse at 50% 40%, rgba(52, 211, 153, 0.10), transparent 50%),
+      radial-gradient(ellipse at 80% 80%, rgba(96, 165, 250, 0.06), transparent 40%),
+      linear-gradient(180deg, #0a1218, #0a0e17);
+  }
+  .slide-bg--amber {
+    background:
+      radial-gradient(ellipse at 30% 30%, rgba(251, 191, 36, 0.08), transparent 50%),
+      radial-gradient(ellipse at 75% 60%, rgba(167, 139, 250, 0.06), transparent 40%),
+      linear-gradient(180deg, #12100a, #0a0e17);
+  }
+
+  /* === SLIDE CONTENT AREA === */
+  .slide-content {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    padding: 3.5rem 4rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* === TYPOGRAPHY === */
+  h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(2rem, 3.2vw, 3rem);
+    font-weight: 700;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+  }
+  h2 {
+    font-family: var(--font-heading);
+    font-size: clamp(1.4rem, 2.2vw, 2rem);
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    margin-bottom: 1.2rem;
+  }
+  h3 {
+    font-family: var(--font-heading);
+    font-size: clamp(1rem, 1.4vw, 1.3rem);
+    font-weight: 500;
+    color: var(--accent-violet);
+    margin-bottom: 0.8rem;
+  }
+  p {
+    font-size: clamp(0.9rem, 1.2vw, 1.1rem);
+    line-height: 1.8;
+    color: var(--text-primary);
+    margin-bottom: 0.8rem;
+  }
+  .text-muted { color: var(--text-secondary); }
+  .text-accent-blue { color: var(--accent-blue); }
+  .text-accent-violet { color: var(--accent-violet); }
+  .text-accent-green { color: var(--accent-green); }
+
+  /* === ACCENT LINE === */
+  .accent-line {
+    width: 80px;
+    height: 3px;
+    border-radius: 2px;
+    background: linear-gradient(90deg, var(--accent-blue), var(--accent-violet));
+    margin: 1rem 0;
+  }
+  .accent-line--center { margin: 1rem auto; }
+  .accent-line--green {
+    background: linear-gradient(90deg, var(--accent-green), transparent);
+  }
+
+  /* === GLASS CARD === */
+  .glass-card {
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius);
+    padding: 1.5rem 2rem;
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+  }
+  .glass-card--accent-left {
+    border-left: 3px solid var(--accent-blue);
+  }
+  .glass-card--glow {
+    box-shadow: 0 0 30px rgba(96, 165, 250, 0.08),
+                0 8px 32px rgba(0, 0, 0, 0.3);
+  }
+
+  /* === METRIC BOX === */
+  .metric-box {
+    text-align: center;
+    padding: 1.5rem;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius);
+    backdrop-filter: blur(var(--glass-blur));
+  }
+  .metric-value {
+    font-family: var(--font-mono);
+    font-size: clamp(2rem, 3.5vw, 3.2rem);
+    font-weight: 700;
+    background: linear-gradient(135deg, var(--accent-blue), var(--accent-violet));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .metric-label {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-top: 0.4rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  /* === TABLE === */
+  table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    font-size: 0.9rem;
+  }
+  th {
+    padding: 0.8rem 1.2rem;
+    background: var(--bg-elevated);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+    text-align: left;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  td {
+    padding: 0.7rem 1.2rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.06);
+  }
+  tr:last-child td { border-bottom: none; }
+
+  /* === CODE BLOCK === */
+  pre {
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(148, 163, 184, 0.08);
+    border-radius: var(--radius-sm);
+    padding: 1.2rem 1.5rem;
+    overflow-x: auto;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    line-height: 1.7;
+    color: var(--accent-green);
+  }
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    background: rgba(52, 211, 153, 0.08);
+    color: var(--accent-green);
+  }
+  pre code { padding: 0; background: none; }
+
+  /* === BLOCKQUOTE === */
+  blockquote {
+    padding: 1.5rem 2rem;
+    border-left: 3px solid var(--accent-blue);
+    background: rgba(17, 24, 39, 0.6);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    border: 1px solid var(--glass-border);
+    border-left: 3px solid var(--accent-blue);
+    font-size: 1.15rem;
+    line-height: 1.7;
+    font-style: italic;
+    color: var(--text-secondary);
+  }
+  blockquote strong { color: var(--accent-blue); font-style: normal; }
+
+  /* === LIST === */
+  ul, ol {
+    padding-left: 0;
+    list-style: none;
+  }
+  ul li, ol li {
+    padding: 0.5rem 0 0.5rem 1.5rem;
+    position: relative;
+    line-height: 1.7;
+  }
+  ul li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 1rem;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent-blue);
+  }
+  ol { counter-reset: slide-ol; }
+  ol li { counter-increment: slide-ol; }
+  ol li::before {
+    content: counter(slide-ol);
+    position: absolute;
+    left: 0;
+    top: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--accent-violet);
+    font-weight: 600;
+  }
+
+  /* ======================= */
+  /* === LAYOUT VARIANTS === */
+  /* ======================= */
+
+  /* --- TITLE SLIDE --- */
+  .layout-title .slide-content {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 0.5rem;
+  }
+  .layout-title h1 {
+    font-size: clamp(2.4rem, 4vw, 3.6rem);
+    font-weight: 700;
+    max-width: 80%;
+  }
+  .layout-title .subtitle {
+    font-size: clamp(1rem, 1.5vw, 1.3rem);
+    color: var(--text-secondary);
+    letter-spacing: 0.04em;
+    max-width: 70%;
+  }
+  .layout-title .meta {
+    font-size: 0.85rem;
+    color: var(--text-tertiary);
+    margin-top: 1rem;
+    font-family: var(--font-mono);
+    letter-spacing: 0.06em;
+  }
+
+  /* --- SECTION DIVIDER --- */
+  .layout-section .slide-content {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+  .layout-section h2 {
+    font-size: clamp(2rem, 3vw, 2.8rem);
+    font-weight: 600;
+  }
+  .layout-section .section-number {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--accent-blue);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+  }
+
+  /* --- CONTENT SLIDE --- */
+  .layout-content .slide-content {
+    justify-content: flex-start;
+    gap: 1rem;
+  }
+  .layout-content .body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+
+  /* --- SPLIT SLIDE (two columns) --- */
+  .layout-split .slide-content {
+    gap: 1rem;
+  }
+  .split-columns {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: start;
+  }
+  .split-col {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+  .split-divider {
+    width: 1px;
+    align-self: stretch;
+    background: linear-gradient(180deg, transparent, var(--glass-border), transparent);
+  }
+
+  /* --- DATA / METRICS SLIDE --- */
+  .layout-data .slide-content {
+    gap: 1.5rem;
+  }
+  .metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.2rem;
+    flex: 1;
+    align-content: center;
+  }
+
+  /* --- QUOTE SLIDE --- */
+  .layout-quote .slide-content {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 4rem 6rem;
+  }
+  .layout-quote blockquote {
+    border: none;
+    border-left: none;
+    background: none;
+    font-size: clamp(1.3rem, 2vw, 1.8rem);
+    line-height: 1.6;
+    max-width: 80%;
+    color: var(--text-primary);
+  }
+  .layout-quote .attribution {
+    font-size: 0.9rem;
+    color: var(--text-tertiary);
+    margin-top: 1.5rem;
+    font-style: normal;
+  }
+
+  /* --- VISUAL SLIDE (full image) --- */
+  .layout-visual .slide-content {
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 2rem 3rem;
+  }
+  .layout-visual img, .layout-visual svg {
+    max-width: 90%;
+    max-height: 70%;
+    border-radius: var(--radius);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  }
+
+  /* --- CONCLUSION SLIDE --- */
+  .layout-conclusion .slide-content {
+    gap: 1.2rem;
+  }
+  .layout-conclusion ul li::before {
+    background: var(--accent-green);
+    width: 8px;
+    height: 8px;
+  }
+
+  /* === ANIMATIONS === */
+  @keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .slide.active .animate-in {
+    animation: fadeInUp 0.4s cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+  .slide.active .delay-1 { animation-delay: 0.08s; }
+  .slide.active .delay-2 { animation-delay: 0.16s; }
+  .slide.active .delay-3 { animation-delay: 0.24s; }
+  .slide.active .delay-4 { animation-delay: 0.32s; }
+  .slide.active .delay-5 { animation-delay: 0.40s; }
+
+  /* === NAVIGATION === */
+  .nav-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 0.6rem 1rem;
+    background: rgba(10, 14, 23, 0.85);
+    backdrop-filter: blur(12px);
+    border-top: 1px solid var(--glass-border);
+  }
+  .nav-btn {
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    background: var(--glass-bg);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-transform: uppercase;
+  }
+  .nav-btn:hover { background: rgba(96, 165, 250, 0.12); border-color: rgba(96, 165, 250, 0.3); }
+  .nav-btn:disabled { opacity: 0.4; cursor: default; }
+  .nav-counter {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--text-tertiary);
+    min-width: 5rem;
+    text-align: center;
+  }
+  .nav-title {
+    font-family: var(--font-heading);
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    max-width: 40vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .nav-fullscreen {
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    background: var(--glass-bg);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: all 0.2s ease;
+  }
+  .nav-fullscreen:hover { color: var(--text-primary); background: rgba(96, 165, 250, 0.12); }
+
+  /* === PROGRESS BAR === */
+  .progress-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    height: 2px;
+    background: linear-gradient(90deg, var(--accent-blue), var(--accent-violet));
+    transition: width 0.3s ease;
+    z-index: 101;
+  }
+
+  /* === PRINT === */
+  @media print {
+    .nav-bar, .progress-bar { display: none; }
+    .slide {
+      position: relative;
+      opacity: 1;
+      visibility: visible;
+      page-break-after: always;
+      height: 100vh;
+    }
+    .slide-inner {
+      width: 100%;
+      box-shadow: none;
+      border: none;
+    }
+  }
+
+  /* === RESPONSIVE === */
+  @media (max-width: 768px) {
+    .slide-content { padding: 2rem 2.5rem; }
+    .layout-title h1 { font-size: 2rem; }
+    .split-columns { grid-template-columns: 1fr; }
+    .nav-title { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<div class="deck" id="deck">
+  <!-- SLIDES GO HERE -->
+</div>
+
+<div class="nav-bar">
+  <button class="nav-btn" id="prevBtn" onclick="go(-1)">Prev</button>
+  <span class="nav-title" id="deckTitle">{{TITLE}}</span>
+  <span class="nav-counter" id="counter">1 / N</span>
+  <button class="nav-btn" id="nextBtn" onclick="go(1)">Next</button>
+  <button class="nav-fullscreen" onclick="toggleFS()" title="Fullscreen">&#x26F6;</button>
+</div>
+<div class="progress-bar" id="progress"></div>
+
+<script>
+  const slides = document.querySelectorAll('.slide');
+  let cur = 0;
+  function show(i) {
+    slides.forEach((s, idx) => s.classList.toggle('active', idx === i));
+    document.getElementById('counter').textContent = (i + 1) + ' / ' + slides.length;
+    document.getElementById('progress').style.width = ((i + 1) / slides.length * 100) + '%';
+    document.getElementById('prevBtn').disabled = i === 0;
+    document.getElementById('nextBtn').disabled = i === slides.length - 1;
+  }
+  function go(d) {
+    const next = Math.max(0, Math.min(slides.length - 1, cur + d));
+    if (next !== cur) { cur = next; show(cur); }
+  }
+  function toggleFS() {
+    if (!document.fullscreenElement) document.documentElement.requestFullscreen();
+    else document.exitFullscreen();
+  }
+  document.addEventListener('keydown', e => {
+    if (e.key === 'ArrowRight' || e.key === ' ' || e.key === 'PageDown') { e.preventDefault(); go(1); }
+    if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.preventDefault(); go(-1); }
+    if (e.key === 'f' || e.key === 'F') toggleFS();
+    if (e.key === 'Escape' && document.fullscreenElement) document.exitFullscreen();
+  });
+  // Touch swipe
+  let touchX = 0;
+  document.addEventListener('touchstart', e => { touchX = e.touches[0].clientX; });
+  document.addEventListener('touchend', e => {
+    const dx = e.changedTouches[0].clientX - touchX;
+    if (Math.abs(dx) > 50) go(dx < 0 ? 1 : -1);
+  });
+  show(0);
+</script>
+</body>
+</html>
+```
+
+## Slide HTML Patterns
+
+### Title Slide
+
+```html
+<div class="slide layout-title" data-bg="blue">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--violet"></div>
+    <div class="slide-content">
+      <h1 class="animate-in">Presentation Title</h1>
+      <div class="accent-line accent-line--center animate-in delay-1"></div>
+      <p class="subtitle animate-in delay-2">Subtitle or description goes here</p>
+      <p class="meta animate-in delay-3">Author &mdash; Date</p>
+    </div>
+  </div>
+</div>
+```
+
+### Content Slide
+
+```html
+<div class="slide layout-content">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--blue"></div>
+    <div class="slide-content">
+      <h2 class="animate-in">Section Heading</h2>
+      <div class="accent-line animate-in delay-1"></div>
+      <div class="body">
+        <div class="glass-card glass-card--accent-left animate-in delay-2">
+          <p><strong>Key Point:</strong> Important insight here</p>
+        </div>
+        <ul>
+          <li class="animate-in delay-3">First supporting point</li>
+          <li class="animate-in delay-4">Second supporting point</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Split Slide
+
+```html
+<div class="slide layout-split">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--blue"></div>
+    <div class="slide-content">
+      <h2 class="animate-in">Comparison Title</h2>
+      <div class="accent-line animate-in delay-1"></div>
+      <div class="split-columns">
+        <div class="split-col animate-in delay-2">
+          <h3>Left Column</h3>
+          <div class="glass-card">
+            <p>Content for left side</p>
+          </div>
+        </div>
+        <div class="split-col animate-in delay-3">
+          <h3>Right Column</h3>
+          <div class="glass-card">
+            <p>Content for right side</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Data / Metrics Slide
+
+```html
+<div class="slide layout-data">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--violet"></div>
+    <div class="slide-content">
+      <h2 class="animate-in">Key Metrics</h2>
+      <div class="accent-line animate-in delay-1"></div>
+      <div class="metrics-grid">
+        <div class="metric-box animate-in delay-2">
+          <div class="metric-value">30</div>
+          <div class="metric-label">Domains</div>
+        </div>
+        <div class="metric-box animate-in delay-3">
+          <div class="metric-value">5</div>
+          <div class="metric-label">Stages</div>
+        </div>
+        <div class="metric-box animate-in delay-4">
+          <div class="metric-value">150+</div>
+          <div class="metric-label">Theories</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Quote Slide
+
+```html
+<div class="slide layout-quote">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--amber"></div>
+    <div class="slide-content">
+      <div class="accent-line accent-line--center animate-in"></div>
+      <blockquote class="animate-in delay-1">
+        "The insight goes here, formatted as a prominent quote."
+      </blockquote>
+      <p class="attribution animate-in delay-2">&mdash; Source</p>
+    </div>
+  </div>
+</div>
+```
+
+### Conclusion Slide
+
+```html
+<div class="slide layout-conclusion">
+  <div class="slide-inner">
+    <div class="slide-bg slide-bg--green"></div>
+    <div class="slide-content">
+      <h2 class="animate-in">Key Takeaways</h2>
+      <div class="accent-line accent-line--green animate-in delay-1"></div>
+      <ul>
+        <li class="animate-in delay-2">First conclusion point</li>
+        <li class="animate-in delay-3">Second conclusion point</li>
+        <li class="animate-in delay-4">Third conclusion point</li>
+      </ul>
+    </div>
+  </div>
+</div>
+```
+
+## Background Selection Guide
+
+| Content Type | Background | Rationale |
+|-------------|-----------|-----------|
+| Title / intro | `--violet` | Warm, inviting |
+| Body content | `--blue` | Neutral, readable |
+| Data / metrics | `--violet` | Emphasis |
+| Theory / concepts | `--blue` | Analytical tone |
+| Conclusions | `--green` | Completion, positive |
+| Warnings / caveats | `--amber` | Attention |
+| Quotes / insights | `--amber` | Warmth |
+
+## Deployment (GitHub Pages)
+
+Generated HTML files are self-contained and can be served directly from any
+static hosting. In kesson-space they live under `content/guides/` and are
+loaded into an iframe by `openRichSlideViewer()` in `src/slide-viewer.js`.

--- a/index.html
+++ b/index.html
@@ -339,16 +339,16 @@
 
   <script type="module" src="./src/pages/e2e-auto-run.js"></script>
 
-  <!-- Slide viewer launcher -->
+  <!-- Slide viewer launcher — CHANGED(2026-03-24) switched to rich-slides (iframe of pre-generated HTML) -->
   <script type="module">
     const btn = document.getElementById('slide-test-btn');
     if (btn) {
       btn.addEventListener('click', async () => {
-        const { openSlideViewer } = await import('./src/slide-viewer.js');
-        const res = await fetch('./content/guides/meta-overview.md');
-        if (!res.ok) return;
-        const markdownText = await res.text();
-        openSlideViewer({ markdownText, title: '欠損駆動思考 — 全体像 [TEST]' });
+        const { openRichSlideViewer } = await import('./src/slide-viewer.js');
+        openRichSlideViewer({
+          htmlUrl: './content/guides/meta-overview.html',
+          title: '欠損駆動思考 — 全体像'
+        });
       });
     }
   </script>

--- a/scripts/generate-rich-slides.py
+++ b/scripts/generate-rich-slides.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""
+generate_slides.py — Convert Markdown to rich 16:9 HTML slide deck.
+
+Usage:
+    python generate_slides.py --input slides.md --output slides.html [--title "Title"] [--lang ja]
+    python generate_slides.py slides.md  # output defaults to same name with .html
+
+Input format:
+    - Slides separated by `---` on its own line
+    - Optional YAML frontmatter between opening `---` and second `---`
+    - Layout hints via HTML comments: <!-- layout: split -->
+    - Supports: headings, paragraphs, lists, tables, blockquotes, code blocks, images
+
+Ported from: creation-space/transform/scripts/generate-rich-slides.py
+Adapted for: kesson-space
+"""
+# CHANGED(2026-03-24) — ported from creation-space, paths adapted for kesson-space
+
+import argparse
+import re
+import sys
+import json
+from pathlib import Path
+from html import escape
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter
+# ---------------------------------------------------------------------------
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    m = re.match(r'^---\n(.*?)\n---\n(.*)$', text, re.DOTALL)
+    if not m:
+        return {}, text.strip()
+    meta = {}
+    for line in m.group(1).split('\n'):
+        idx = line.find(':')
+        if idx > 0:
+            key = line[:idx].strip()
+            val = line[idx + 1:].strip().strip('"').strip("'")
+            meta[key] = val
+    return meta, m.group(2).strip()
+
+
+# ---------------------------------------------------------------------------
+# Markdown → HTML (lightweight, no external deps)
+# ---------------------------------------------------------------------------
+
+def md_to_html(md: str) -> str:
+    """Convert a single slide's markdown to HTML. Minimal but sufficient."""
+    lines = md.split('\n')
+    out = []
+    in_list = None  # 'ul' or 'ol'
+    in_code = False
+    code_buf = []
+    in_table = False
+    table_buf = []
+    delay = 0
+
+    def next_delay():
+        nonlocal delay
+        delay += 1
+        return f'animate-in delay-{min(delay, 5)}'
+
+    def flush_list():
+        nonlocal in_list
+        if in_list:
+            out.append(f'</{in_list}>')
+            in_list = None
+
+    def flush_table():
+        nonlocal in_table, table_buf
+        if not in_table:
+            return
+        in_table = False
+        rows = table_buf
+        table_buf = []
+        if not rows:
+            return
+        html = f'<table class="{next_delay()}">'
+        for i, row in enumerate(rows):
+            cells = [c.strip() for c in row.strip('|').split('|')]
+            # Skip separator row
+            if all(re.match(r'^[-:]+$', c) for c in cells):
+                continue
+            tag = 'th' if i == 0 else 'td'
+            html += '<tr>' + ''.join(f'<{tag}>{inline(c)}</{tag}>' for c in cells) + '</tr>'
+        html += '</table>'
+        out.append(html)
+
+    def inline(text: str) -> str:
+        """Inline markdown: bold, italic, code, links, images."""
+        # Images
+        text = re.sub(r'!\[([^\]]*)\]\(([^)]+)\)', r'<img src="\2" alt="\1">', text)
+        # Links
+        text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2" style="color:var(--accent-blue)">\1</a>', text)
+        # Bold
+        text = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', text)
+        # Italic
+        text = re.sub(r'\*(.+?)\*', r'<em>\1</em>', text)
+        # Inline code
+        text = re.sub(r'`([^`]+)`', r'<code>\1</code>', text)
+        return text
+
+    for line in lines:
+        # Code fence
+        if line.strip().startswith('```'):
+            if in_code:
+                out.append(f'<pre class="{next_delay()}"><code>' + escape('\n'.join(code_buf)) + '</code></pre>')
+                code_buf = []
+                in_code = False
+            else:
+                flush_list()
+                flush_table()
+                in_code = True
+            continue
+        if in_code:
+            code_buf.append(line)
+            continue
+
+        # Table
+        if '|' in line and line.strip().startswith('|'):
+            flush_list()
+            if not in_table:
+                in_table = True
+            table_buf.append(line)
+            continue
+        else:
+            flush_table()
+
+        stripped = line.strip()
+        if not stripped:
+            flush_list()
+            continue
+
+        # Headings
+        hm = re.match(r'^(#{1,3})\s+(.+)$', stripped)
+        if hm:
+            flush_list()
+            level = len(hm.group(1))
+            tag = f'h{level}'
+            out.append(f'<{tag} class="{next_delay()}">{inline(hm.group(2))}</{tag}>')
+            if level <= 2:
+                suffix = '--green' if level == 2 and any(kw in hm.group(2) for kw in ['結論', 'まとめ', 'Conclusion', 'Takeaway']) else ''
+                out.append(f'<div class="accent-line{" accent-line" + suffix if suffix else ""} {next_delay()}"></div>')
+            continue
+
+        # Blockquote
+        if stripped.startswith('>'):
+            flush_list()
+            quote_text = inline(stripped.lstrip('> '))
+            out.append(f'<blockquote class="{next_delay()}">{quote_text}</blockquote>')
+            continue
+
+        # Unordered list
+        um = re.match(r'^[-*]\s+(.+)$', stripped)
+        if um:
+            if in_list != 'ul':
+                flush_list()
+                in_list = 'ul'
+                out.append('<ul>')
+            out.append(f'<li class="{next_delay()}">{inline(um.group(1))}</li>')
+            continue
+
+        # Ordered list
+        om = re.match(r'^\d+\.\s+(.+)$', stripped)
+        if om:
+            if in_list != 'ol':
+                flush_list()
+                in_list = 'ol'
+                out.append('<ol>')
+            out.append(f'<li class="{next_delay()}">{inline(om.group(1))}</li>')
+            continue
+
+        # Paragraph
+        flush_list()
+        out.append(f'<p class="{next_delay()}">{inline(stripped)}</p>')
+
+    flush_list()
+    flush_table()
+    if in_code and code_buf:
+        out.append(f'<pre class="{next_delay()}"><code>' + escape('\n'.join(code_buf)) + '</code></pre>')
+
+    return '\n'.join(out)
+
+
+# ---------------------------------------------------------------------------
+# Layout classification
+# ---------------------------------------------------------------------------
+
+def classify_slide(html: str, index: int, total: int, hint: str = '') -> tuple[str, str]:
+    """Return (layout_class, bg_class) for a slide."""
+    if hint:
+        layout = hint
+    elif index == 0:
+        layout = 'title'
+    elif index == total - 1:
+        layout = 'conclusion'
+    elif '<img ' in html and html.count('<p') <= 1:
+        layout = 'visual'
+    elif '<table' in html:
+        layout = 'data'
+    elif '<blockquote' in html and html.count('<p') <= 2 and '<ul>' not in html and '<ol>' not in html:
+        layout = 'quote'
+    elif 'metric-value' in html or 'metric-box' in html:
+        layout = 'data'
+    else:
+        layout = 'content'
+
+    bg_map = {
+        'title': 'violet',
+        'section': 'blue',
+        'content': 'blue',
+        'split': 'blue',
+        'data': 'violet',
+        'visual': 'blue',
+        'quote': 'amber',
+        'conclusion': 'green',
+    }
+    bg = bg_map.get(layout, 'blue')
+    return f'layout-{layout}', f'slide-bg--{bg}'
+
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+def build_slides_html(md_text: str, title: str = '', lang: str = 'ja') -> str:
+    meta, body = parse_frontmatter(md_text)
+    title = title or meta.get('title', 'Slides')
+    lang = lang or meta.get('lang', 'ja')
+
+    chunks = re.split(r'\n---\n', body)
+    chunks = [c.strip() for c in chunks if c.strip()]
+
+    slides_html = []
+    for i, chunk in enumerate(chunks):
+        # Check for layout hint comment
+        hint = ''
+        hm = re.search(r'<!--\s*layout:\s*(\w+)\s*-->', chunk)
+        if hm:
+            hint = hm.group(1)
+            chunk = chunk[:hm.start()] + chunk[hm.end():]
+
+        inner_html = md_to_html(chunk.strip())
+        layout_cls, bg_cls = classify_slide(inner_html, i, len(chunks), hint)
+
+        active = ' active' if i == 0 else ''
+        slide = f'''<div class="slide {layout_cls}{active}">
+  <div class="slide-inner">
+    <div class="slide-bg {bg_cls}"></div>
+    <div class="slide-content">
+{inner_html}
+    </div>
+  </div>
+</div>'''
+        slides_html.append(slide)
+
+    # Read the design-spec template
+    # CHANGED(2026-03-24) — kesson-space path: docs/rich-slides-design-spec.md
+    spec_path = Path(__file__).parent.parent / 'docs' / 'rich-slides-design-spec.md'
+    if spec_path.exists():
+        spec_text = spec_path.read_text()
+        # Extract the HTML shell from the code block
+        shell_match = re.search(r'```html\n(<!DOCTYPE html>.*?)</body>\s*</html>\s*```', spec_text, re.DOTALL)
+        if shell_match:
+            template = shell_match.group(1) + '</body>\n</html>'
+            # Insert slides
+            template = template.replace('  <!-- SLIDES GO HERE -->', '\n'.join(slides_html))
+            template = template.replace('{{TITLE}}', escape(title))
+            template = template.replace('lang="ja"', f'lang="{lang}"')
+            return template
+
+    # Fallback: minimal shell
+    return _fallback_shell(slides_html, title, lang)
+
+
+def _fallback_shell(slides_html: list, title: str, lang: str) -> str:
+    return f'''<!DOCTYPE html>
+<html lang="{lang}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{escape(title)}</title>
+<style>
+*, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+html, body {{ width: 100%; height: 100%; background: #0a0e17; color: #f1f5f9; font-family: "Inter", "Noto Sans JP", system-ui, sans-serif; overflow: hidden; }}
+.deck {{ width: 100vw; height: 100vh; position: relative; }}
+.slide {{ position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; opacity: 0; visibility: hidden; transition: opacity 0.28s ease, visibility 0.28s ease; }}
+.slide.active {{ opacity: 1; visibility: visible; }}
+.slide-inner {{ width: min(92vw, calc(88vh * 16 / 9)); aspect-ratio: 16 / 9; border-radius: 16px; border: 1px solid rgba(148,163,184,0.14); overflow: hidden; position: relative; box-shadow: 0 24px 80px rgba(0,0,0,0.5); }}
+.slide-bg {{ position: absolute; inset: 0; background: linear-gradient(180deg, #0c1220, #0a0e17); }}
+.slide-content {{ position: relative; z-index: 1; width: 100%; height: 100%; padding: 3.5rem 4rem; display: flex; flex-direction: column; }}
+h1 {{ font-size: 2.5rem; font-weight: 700; }}
+h2 {{ font-size: 1.8rem; font-weight: 600; margin-bottom: 1rem; }}
+p {{ font-size: 1rem; line-height: 1.8; margin-bottom: 0.8rem; }}
+</style>
+</head>
+<body>
+<div class="deck" id="deck">
+{chr(10).join(slides_html)}
+</div>
+<script>
+const slides=document.querySelectorAll('.slide');let cur=0;
+function show(i){{slides.forEach((s,idx)=>s.classList.toggle('active',idx===i));}}
+function go(d){{const n=Math.max(0,Math.min(slides.length-1,cur+d));if(n!==cur){{cur=n;show(cur);}}}}
+document.addEventListener('keydown',e=>{{if(e.key==='ArrowRight'||e.key===' '){{e.preventDefault();go(1);}}if(e.key==='ArrowLeft'){{e.preventDefault();go(-1);}}}}); show(0);
+</script>
+</body>
+</html>'''
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate rich HTML slides from Markdown')
+    parser.add_argument('input_positional', nargs='?', help='Input Markdown file (positional)')
+    parser.add_argument('--input', '-i', default='', help='Input Markdown file')
+    parser.add_argument('--output', '-o', default='', help='Output HTML file')
+    parser.add_argument('--title', '-t', default='', help='Presentation title')
+    parser.add_argument('--lang', '-l', default='ja', help='Language code')
+    args = parser.parse_args()
+
+    input_path = args.input or args.input_positional
+    if not input_path:
+        parser.error('Input file is required (positional or --input)')
+
+    output_path = args.output or str(Path(input_path).with_suffix('.html'))
+
+    md_text = Path(input_path).read_text(encoding='utf-8')
+    html = build_slides_html(md_text, title=args.title, lang=args.lang)
+    Path(output_path).write_text(html, encoding='utf-8')
+    print(f'Generated: {output_path} ({len(html):,} bytes)')
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/rich-slides/SKILL.md
+++ b/skills/rich-slides/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: rich-slides
+description: >
+  Generate visually rich, self-contained 16:9 HTML slide decks from Markdown input.
+  Use this skill whenever the user wants to create slides, presentations, or deck-style
+  content for browser viewing or web publishing. Triggers on: "slides", "presentation",
+  "deck", "slide show", or any request to convert markdown/text into a visual slide format.
+  Produces HTML files, not .pptx.
+---
+
+# Rich Slides — MD to Browser-Ready 16:9 HTML Slides
+
+## What This Skill Does
+
+Transforms Markdown content into a self-contained, visually polished HTML file that
+displays as a 16:9 slide deck in the browser. The output is a single `.html` file with
+all CSS and JS inlined — no external dependencies, ready to deploy to any static site.
+
+## Design Philosophy
+
+The visual language is a dark glassmorphism theme matching kesson-space's design system.
+Deep navy/charcoal backgrounds, frosted glass cards, subtle gradient accents
+(blue -> violet -> green), and generous typography.
+
+## Workflow
+
+### Step 1: Understand the Input
+
+The user provides content in one of these forms:
+
+1. **Markdown with `---` slide separators** — Each `---` on its own line starts a new slide
+2. **Plain text or bullet points** — You structure it into slides
+3. **A file path to an existing .md** — Read and convert
+4. **A topic** — You write the content AND create the slides
+
+### Step 2: Generate the HTML
+
+Run the generation script:
+
+```bash
+python3 scripts/generate-rich-slides.py \
+  --input input.md \
+  --output output.html \
+  --title "Presentation Title" \
+  --lang ja
+```
+
+Or with positional argument (output defaults to .html extension):
+
+```bash
+python3 scripts/generate-rich-slides.py content/guides/my-slides.md
+```
+
+### Step 3: Display via slide-viewer
+
+The generated HTML is displayed in the browser via `openRichSlideViewer()`:
+
+```js
+import { openRichSlideViewer } from './src/slide-viewer.js';
+openRichSlideViewer({ htmlUrl: './content/guides/my-slides.html', title: 'My Title' });
+```
+
+## File Organization
+
+```
+scripts/
+  generate-rich-slides.py           <- Python script for MD -> HTML conversion
+
+docs/
+  rich-slides-design-spec.md        <- Detailed CSS patterns and layout templates
+
+skills/rich-slides/
+  SKILL.md                          <- This file (skill definition)
+
+src/
+  slide-viewer.js                   <- openRichSlideViewer() + openSlideViewer()
+```
+
+## References
+
+- Read `docs/rich-slides-design-spec.md` for detailed CSS patterns, HTML structures,
+  and layout templates for each slide type
+- Ported from creation-space (2026-03-24)

--- a/src/slide-viewer.js
+++ b/src/slide-viewer.js
@@ -174,6 +174,65 @@ export async function openSlideViewer({ markdownText, title = '', mdBaseUrl }) {
     }
 }
 
+// CHANGED(2026-03-24) — ported openRichSlideViewer from creation-space
+/**
+ * Open a pre-generated rich HTML slide deck inside the overlay via iframe.
+ * The rich HTML file has its own navigation, so we hide the parent toolbar.
+ *
+ * @param {Object} options
+ * @param {string} options.htmlUrl - URL of the rich HTML slide file
+ * @param {string} [options.title] - Title for the overlay aria-label
+ */
+export function openRichSlideViewer({ htmlUrl, title = '' }) {
+    if (!htmlUrl) return;
+
+    try {
+        if (!overlayNode) {
+            overlayNode = createOverlay();
+        }
+
+        const stage = getOverlayPart('.slide-viewer-stage');
+        if (!stage) return;
+
+        stage.innerHTML = '';
+        slidesState = [];
+
+        // Hide parent toolbar — the rich HTML has its own nav
+        const toolbar = getOverlayPart('.slide-viewer-toolbar');
+        if (toolbar) {
+            toolbar.style.display = 'none';
+        }
+
+        // Create iframe that fills the frame
+        const iframe = document.createElement('iframe');
+        iframe.src = htmlUrl;
+        iframe.style.cssText = 'width:100%;height:100%;border:none;border-radius:inherit;';
+        iframe.setAttribute('allowfullscreen', '');
+        iframe.setAttribute('loading', 'lazy');
+        stage.appendChild(iframe);
+
+        // Focus iframe once loaded so keyboard nav works inside it
+        iframe.addEventListener('load', () => {
+            try { iframe.contentWindow.focus(); } catch (_) { /* cross-origin */ }
+        });
+
+        overlayNode.classList.add('visible');
+        overlayNode.setAttribute('aria-label', title || 'Rich Slides');
+        setBodyScrollLock(true);
+
+        // Only handle Escape at the parent level
+        const richKeyHandler = (event) => {
+            if (event.key === 'Escape') {
+                window.removeEventListener('keydown', richKeyHandler);
+                closeSlideViewer();
+            }
+        };
+        window.addEventListener('keydown', richKeyHandler);
+    } catch (err) {
+        console.error('[slide-viewer] rich slide ERROR:', err);
+    }
+}
+
 export function closeSlideViewer() {
     window.removeEventListener('keydown', onKeyDown);
     setBodyScrollLock(false);


### PR DESCRIPTION
## Summary
- Ported the rich-slides pipeline from creation-space: Python script generates self-contained 16:9 HTML slide decks from Markdown
- Added `openRichSlideViewer()` to `src/slide-viewer.js` which displays pre-generated HTML in an iframe overlay
- Switched the Overview button in index.html to use the rich-slides pipeline instead of the old markdown-direct renderer
- Generated `content/guides/meta-overview.html` as the first test slide deck
- Ported design-spec and SKILL.md documentation

## Changes
- `scripts/generate-rich-slides.py` -- MD to HTML converter (no external deps)
- `docs/rich-slides-design-spec.md` -- CSS/layout template (used by the script)
- `src/slide-viewer.js` -- added `openRichSlideViewer()`, existing `openSlideViewer()` preserved
- `content/guides/meta-overview.html` -- generated test slide deck
- `index.html` -- Overview button now uses `openRichSlideViewer`
- `skills/rich-slides/SKILL.md` -- skill definition for future use

## Test plan
- [ ] `node tests/config-consistency.test.js` passes (62/62)
- [ ] Local server: click Overview button in GUIDES section -> rich HTML slides display in iframe overlay
- [ ] Arrow keys / swipe navigate slides within the iframe
- [ ] Escape key closes the overlay
- [ ] Old `openSlideViewer()` still exported and usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)