### PR TITLE
feat: hide devlog feature via CSS (#151)

### DIFF
--- a/devlog.html
+++ b/devlog.html
@@ -15,6 +15,18 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@300;400&amp;display=swap" rel="stylesheet">
 
   <style>
+    /* CHANGED(2026-03-24): #151 — Devlog feature hidden */
+    #content-overlay,
+    #bg-container { display: none !important; }
+    body::after {
+      content: 'This page is currently unavailable.';
+      display: block;
+      text-align: center;
+      padding: 4rem 1rem;
+      color: rgba(180, 200, 230, 0.6);
+      font-size: 1rem;
+    }
+
     :root {
       --overlay-bg-rgb: 5, 5, 8;
       --overlay-opacity-top: 0.3;
@@ -223,11 +235,11 @@
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
-  <!-- Three.js背景 -->
-  <script type="module" src="./src/pages/devlog-bg.js"></script>
+  <!-- CHANGED(2026-03-24): #151 — Devlog feature hidden; scripts disabled to prevent resource loading -->
+  <!-- <script type="module" src="./src/pages/devlog-bg.js"></script> -->
 
-  <!-- Devlogコンテンツローダー -->
-  <script type="module">
+  <!-- Devlogコンテンツローダー (disabled: #151) -->
+  <!-- <script type="module">
     import { marked } from 'marked';
     import DOMPurify from 'dompurify';
 
@@ -471,6 +483,6 @@
     }
 
     loadSession();
-  </script>
+  </script> -->
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,8 @@ import { bootstrapMainScene } from './main/bootstrap.js';
 import { applyPageLanguage, initLanguageListeners } from './main/page-language.js';
 import { attachResizeHandler, createNavMeshFinder, startRenderLoop } from './main/render-loop.js';
 import { getOrbScreenData, refreshNavLanguage, updateNavLabels, updateXLogo, updateXLogoLabel } from './nav-objects.js';
-import { refreshDevlogLanguage } from './devlog/devlog.js';
+// CHANGED(2026-03-24): #151 — Devlog feature hidden; skip initialization to avoid unnecessary resource loading
+// import { refreshDevlogLanguage } from './devlog/devlog.js';
 import { initLangToggle } from './lang-toggle.js';
 import { initMobileNavAutoCollapse } from './main/mobile-nav.js';
 import { initTopbarConsole } from './topbar-console.js';
@@ -67,7 +68,9 @@ if (DEV_MODE) {
 initLanguageListeners({
     refreshGuideLang,
     refreshNavLanguage,
-    refreshDevlogLanguage,
+    // CHANGED(2026-03-24): #151 — Devlog hidden; skip language refresh
+    // refreshDevlogLanguage,
+    refreshDevlogLanguage: () => {},
     refreshArticlesLanguage,
     refreshCreationCardsLanguage,
     refreshGuidesLanguage: () => setGuidesLanguage(detectLang()),

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1773,3 +1773,14 @@
       font-size: 0.68rem;
       letter-spacing: 0.08em;
     }
+
+    /* ============================
+       CHANGED(2026-03-24): #151 — Devlog feature hidden via CSS
+       HTML is preserved for future restoration.
+       ============================ */
+    #devlog-gallery-section {
+      display: none !important;
+    }
+    #devlogOffcanvas {
+      display: none !important;
+    }


### PR DESCRIPTION
## Summary
- Hide Devlog gallery section (`#devlog-gallery-section`) and offcanvas (`#devlogOffcanvas`) via CSS `display: none !important`
- Comment out devlog JS module import in `main.js` to skip initialization and prevent unnecessary resource loading
- Disable scripts in `devlog.html` and show "unavailable" message
- All HTML elements are preserved (not deleted) for future restoration

Closes #151

## Test plan
- [x] `node tests/config-consistency.test.js` passes (62/62)
- [ ] Verify index.html: DEVLOG section and offcanvas are not visible
- [ ] Verify devlog.html shows "unavailable" message
- [ ] Verify no console errors from devlog-related JS
- [ ] Verify other sections (ARTICLES, GUIDES, Three.js) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)