### PR TITLE
fix: remove guide link from meta-overview slide

### DIFF
--- a/content/guides/meta-overview.html
+++ b/content/guides/meta-overview.html
@@ -695,7 +695,6 @@
 <li class="animate-in delay-5"><strong>設計者向け</strong> — 設計判断と運用視点で読む</li>
 <li class="animate-in delay-5"><strong>専門家向け</strong> — 理論比較と検証観点を含む</li>
 </ul>
-<blockquote class="animate-in delay-5">ガイド: <a href="https://uminomae.github.io/pjdhiro/assets/kesson/" style="color:var(--accent-blue)">pjdhiro/kesson</a></blockquote>
     </div>
   </div>
 </div>

--- a/content/guides/meta-overview.md
+++ b/content/guides/meta-overview.md
@@ -135,8 +135,6 @@ status: draft
 - **設計者向け** — 設計判断と運用視点で読む
 - **専門家向け** — 理論比較と検証観点を含む
 
-> ガイド: [pjdhiro/kesson](https://uminomae.github.io/pjdhiro/assets/kesson/)
-
 ---
 
 <!-- layout: conclusion -->


### PR DESCRIPTION
ガイドリンク（pjdhiro/kesson）をスライドから削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)